### PR TITLE
🛠️ ATD-INFRA -> NTP & RADIUS source changed to Management1

### DIFF
--- a/topologies/training-fxf/configlets/ATD-INFRA
+++ b/topologies/training-fxf/configlets/ATD-INFRA
@@ -23,7 +23,7 @@ dns domain arista.lab
 !
 service routing protocols model multi-agent
 !
-ntp server vrf MGMT 192.168.0.1 iburst source Management0
+ntp server vrf MGMT 192.168.0.1 iburst source Management1
 !
 radius-server host 192.168.0.1 vrf MGMT key 7 0207165218120E
 !
@@ -40,7 +40,7 @@ username arista privilege 15 role network-admin secret 5 $1$4VjIjfd1$XkUVulbNDES
 !
 username arista ssh-key ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC+ERvV4GaPq3FzxY8T+5hMF/1T+l8wiPsVCtOrZU4Hy6NCNlAiDBdA/RUtX5/aOu5JvHyPTVHqWJ0qi9BqU3rxCNl/l2/5UZbm9RPzdZ1QCwoYwPB9/j/tYJV8lZdr6t0yGBfxgzD3oW/zF7a+ZtASaMAu7lkgoqPK2pVIGa+Y9ZCsA0Xq756XpLCw+d3pHKHvIkgWLCo9FoeIv8f/bu5u/ztzRE+Nvl+o5add6MxnjsXz3s7BnW2FX6JNjyp0Z+OXjupQc2gcfFvpd/dA2lCNuuaCHkRgyPwIZtWPmNqMRXPp37mlPwV43qDJRVPQkvh0xPxwS35BbzUxWdT+ZLZv
 !
-ip radius source-interface Management0
+ip radius source-interface Management1
 !
 ip routing vrf MGMT
 !

--- a/topologies/training-fxf/configlets/Access-1-BASE
+++ b/topologies/training-fxf/configlets/Access-1-BASE
@@ -1,7 +1,7 @@
 hostname Access-1
 !
-
-interface Management 0
+!
+interface Management1
   vrf MGMT
   ip address 192.168.0.23/24
 

--- a/topologies/training-fxf/configlets/Access-2-BASE
+++ b/topologies/training-fxf/configlets/Access-2-BASE
@@ -1,11 +1,10 @@
 hostname Access-2
 !
-
 !
-interface Management 0
+interface Management1
   vrf MGMT
   ip address 192.168.0.24/24
-  
+
 
 !
 dns domain arista.lab

--- a/topologies/training-fxf/configlets/Core-1-BASE
+++ b/topologies/training-fxf/configlets/Core-1-BASE
@@ -1,8 +1,7 @@
 hostname Core-1
 !
-
 !
-interface Management 0
+interface Management1
   vrf MGMT
   ip address 192.168.0.21/24
 

--- a/topologies/training-fxf/configlets/Core-2-BASE
+++ b/topologies/training-fxf/configlets/Core-2-BASE
@@ -1,8 +1,7 @@
 hostname Core-2
 !
-
 !
-interface Management 0
+interface Management1
   vrf MGMT
   ip address 192.168.0.22/24
 

--- a/topologies/training-fxf/configlets/Router-1-BASE
+++ b/topologies/training-fxf/configlets/Router-1-BASE
@@ -1,7 +1,7 @@
 hostname Router-1
 !
 !
-interface Management 0
+interface Management1
   vrf MGMT
   ip address 192.168.0.12/24
 

--- a/topologies/training-fxf/configlets/Router-2-BASE
+++ b/topologies/training-fxf/configlets/Router-2-BASE
@@ -1,7 +1,7 @@
 hostname Router-2
 !
 !
-interface Management 0
+interface Management 1
   vrf MGMT
   ip address 192.168.0.13/24
 

--- a/topologies/training-fxf/configlets/Wan-1-BASE
+++ b/topologies/training-fxf/configlets/Wan-1-BASE
@@ -1,7 +1,7 @@
 hostname Wan-1
 !
 !
-interface Management 0
+interface Management1
   vrf MGMT
   ip address 192.168.0.11/24
 

--- a/topologies/training-fxf/configlets/Wan-1-OSPF
+++ b/topologies/training-fxf/configlets/Wan-1-OSPF
@@ -1,0 +1,27 @@
+router ospf 1
+   router-id 1.1.1.7
+   passive-interface default
+   no passive-interface Ethernet1
+   no passive-interface Ethernet2
+   no passive-interface Vlan14
+   network 10.0.0.16/30 area 0.0.0.1
+   network 10.0.0.20/30 area 0.0.0.1
+   network 14.0.0.0/24 area 0.0.0.0
+   default-information originate always
+
+
+  interface Vlan14
+   no autostate
+   ip address 14.0.0.254/24
+   ip ospf area 0.0.0.0
+
+  interface Ethernet 1
+    description OSPF Area 1 to Router-1
+    ip ospf network point-to-point
+    ip ospf area 0.0.0.1
+
+
+  interface Ethernet 2
+    description OSPF Area 1 to Router-2
+    ip ospf network point-to-point
+    ip ospf area 0.0.0.1

--- a/topologies/training-fxf/configlets/host-1-BASE
+++ b/topologies/training-fxf/configlets/host-1-BASE
@@ -1,0 +1,25 @@
+hostname host-1
+!
+!
+interface Management1
+  vrf MGMT
+  ip address 192.168.0.41/24
+!
+vlan 14
+!
+interface Vlan14
+   ip address 14.0.0.11/24
+!
+interface Ethernet 1
+  switchport
+  switchport mode access
+  switchport access vlan 14
+!
+ip routing
+ip route 0.0.0.0/0 14.0.0.254
+!
+dns domain arista.lab
+!
+ip routing vrf MGMT
+!
+ip route vrf MGMT 0.0.0.0/0 192.168.0.1

--- a/topologies/training-fxf/configlets/host-11-BASE
+++ b/topologies/training-fxf/configlets/host-11-BASE
@@ -1,0 +1,26 @@
+hostname host-11
+!
+!
+interface Management1
+  vrf MGMT
+  ip address 192.168.0.42/24
+!
+vlan 11
+!
+interface Vlan11
+   ip address 11.0.0.11/24
+!
+interface Ethernet 1
+  switchport
+  switchport mode access
+  switchport access vlan 11
+!
+ip routing
+!
+ip route 0.0.0.0/0 11.0.0.1
+!
+dns domain arista.lab
+!
+ip routing vrf MGMT
+!
+ip route vrf MGMT 0.0.0.0/0 192.168.0.1

--- a/topologies/training-fxf/configlets/host-12-BASE
+++ b/topologies/training-fxf/configlets/host-12-BASE
@@ -1,0 +1,26 @@
+hostname host-12
+!
+!
+interface Management1
+  vrf MGMT
+  ip address 192.168.0.43/24
+!
+vlan 13
+!
+interface Vlan13
+   ip address 13.0.0.11/24
+!
+interface Ethernet 1
+  switchport
+  switchport mode access
+  switchport access vlan 13
+!
+ip routing
+!
+ip route 0.0.0.0/0 13.0.0.1
+!
+dns domain arista.lab
+!
+ip routing vrf MGMT
+!
+ip route vrf MGMT 0.0.0.0/0 192.168.0.1

--- a/topologies/training-fxf/files/menus/training-l3.yaml
+++ b/topologies/training-fxf/files/menus/training-l3.yaml
@@ -1,32 +1,26 @@
 ---
     lab_list:
       reset:
-        additional_commands: 
-          - "bash /home/arista/Broadcaster/pushHostDefaultConfig.sh"
         description: "Reset All Devices to Base Lab (reset)"
     labconfiglets:
       reset:
-        spine1:
-          - "spine1-base"
-        spine2:
-          - "spine2-base"
-        spine3:
-          - "spine3-base"
-        spine4:
-          - "spine4-base"
-        leaf1:
-          - "leaf1-base"
-        leaf2:
-          - "leaf2-base"
-        leaf3:
-          - "leaf3-base"
-        leaf4:
-          - "leaf4-base"
-        host1:
-          - "host1-base"
-        host2:
-          - "host2-base"
-        borderleaf1:
-          - "borderleaf1-base"
-        borderleaf2:
-          - "borderleaf2-base"
+        Wan-1:
+          - "Wan-1-BASE"
+        Router-1:
+          - "Router-1-BASE"
+        Router-2:
+          - "Router-2-BASE"
+        Core-1:
+          - "Core-1-BASE"
+        Core-2:
+          - "Core-2-BASE"
+        Access-1:
+          - "Access-1-BASE"
+        Access-2:
+          - "Access-2-BASE"
+        host-1:
+          - "host-1-BASE"
+        host-11:
+          - "host-11-BASE"
+        host-12:
+          - "host-12-BASE"

--- a/topologies/training-fxf/topo_build.yml
+++ b/topologies/training-fxf/topo_build.yml
@@ -113,30 +113,26 @@ nodes:
        - neighborDevice: Server-14
          neighborPort: Ethernet1
          port: Ethernet3
-servers:
- - Server-1:
-     image_name: "gcr.io/atd-testdrivetraining-dev/hosts-gui/host1:latest"
-     ip_addr: 192.168.0.101
-     port : 6001
-     neighbors:
-       - neighborDevice: Wan-1
-         neighborPort: Ethernet3
-         port: Ethernet1
- - Server-12:
-     image_name: "gcr.io/atd-testdrivetraining-dev/hosts-gui/host1:latest"
-     ip_addr: 192.168.0.102
-     port : 6002
-     neighbors:
-       - neighborDevice: Access-1
-         neighborPort: Ethernet3
-         port: Ethernet1
- - Server-14:
-     image_name: "gcr.io/atd-testdrivetraining-dev/hosts-gui/host1:latest"
-     ip_addr: 192.168.0.103
-     port : 6003
-     neighbors:
-       - neighborDevice: Access-2
-         neighborPort: Ethernet3
-         port: Ethernet1
+  - host-1:
+      ip_addr: 192.168.0.41
+      sys_mac: 00:1c:73:e1:c6:01
+      neighbors:
+        - neighborDevice: Wan-1
+          neighborPort: Ethernet3
+          port: Ethernet1
+  - host-11:
+      ip_addr: 192.168.0.42
+      sys_mac: 00:1c:73:e2:c6:01
+      neighbors:
+        - neighborDevice: Access-1
+          neighborPort: Ethernet3
+          port: Ethernet1
+  - host-12:
+      ip_addr: 192.168.0.43
+      sys_mac: 00:1c:73:e3:c6:01
+      neighbors:
+        - neighborDevice: Access-2
+          neighborPort: Ethernet3
+          port: Ethernet1
 additional_ssh_nodes:
 additional_clab_nodes:

--- a/topologies/training-fxg/files/menus/training-l3.yaml
+++ b/topologies/training-fxg/files/menus/training-l3.yaml
@@ -2,8 +2,6 @@
     lab_list:
       reset:
         description: "Reset All Devices to Base Lab (reset)"
-      OSPF:
-        description: "Load the Wan-1 config for OSPF (OSPF)"
     labconfiglets:
       reset:
         Wan-1:
@@ -26,16 +24,3 @@
           - "host-11-BASE"
         host-12:
           - "host-12-BASE"
-      OSPF:
-        Wan-1:
-          - "Wan-1-BASE"
-          - "Wan-1-OSPF"
-        Router-1:
-        Router-2:
-        Core-1:
-        Core-2:
-        Access-1:
-        Access-2:
-        host-1:
-        host-11:
-        host-12:


### PR DESCRIPTION
🛠️ Access-1-BASE -> Interface Management0 to Management1 🛠️ Access-2-BASE -> Interface Management0 to Management1 🛠️ Core-1-BASE -> Interface Management0 to Management1 🛠️ Core-2-BASE -> Interface Management0 to Management1 🛠️ Router-1-BASE -> Interface Management0 to Management1 🛠️ Router-2-BASE -> Interface Management0 to Management1 🛠️ Wan-1-BASE -> Interface Management0 to Management1 🟢 Wan-1-OSPF -> New OSPF configuration
🟢 host-1-BASE -> New host configuration
🟢 host-11-BASE -> New host configuration
🟢 host-12-BASE -> New host configuration
🛠️ training-l3.yaml -> Menu updated, OSPF removed
🛠️ topo_build.yml -> Server nodes replaced with host nodes