### PR TITLE
Feature/update topology diagrams

### DIFF
--- a/nested-labvm/atd-docker/uilanding/src/html/css/topology.css
+++ b/nested-labvm/atd-docker/uilanding/src/html/css/topology.css
@@ -358,17 +358,19 @@
     margin: 0;
     padding: 0 0 0 15px;
     font-size: 11px;
+    color: #333;
 }
 
 .tooltip-ports li {
     padding: 2px 0;
     font-family: "Monaco", "Consolas", monospace;
+    color: #071c35;
 }
 
 .tooltip-ports em {
     display: block;
     margin-top: 5px;
-    color: #999;
+    color: #666;
     font-size: 11px;
 }
 
@@ -377,7 +379,7 @@
     background-color: #f8f8f8;
     border-radius: 0 0 6px 6px;
     font-size: 11px;
-    color: #888;
+    color: #666;
     text-align: center;
     font-style: italic;
 }

--- a/nested-labvm/atd-docker/uilanding/src/html/css/topology.css
+++ b/nested-labvm/atd-docker/uilanding/src/html/css/topology.css
@@ -303,6 +303,7 @@
 .tooltip-type.device-type-pe { background-color: #4c5cae; }
 .tooltip-type.device-type-p { background-color: #6b7cc9; }
 .tooltip-type.device-type-ce { background-color: #4c5cae; }
+.tooltip-type.device-type-customer { background-color: #78d82c; color: #071c35; }
 .tooltip-type.device-type-core { background-color: #071c35; }
 .tooltip-type.device-type-dci { background-color: #051431; }
 .tooltip-type.device-type-isp,

--- a/nested-labvm/atd-docker/uilanding/src/html/css/topology.css
+++ b/nested-labvm/atd-docker/uilanding/src/html/css/topology.css
@@ -9,9 +9,11 @@
 #interactive-topology {
     position: relative;
     width: 100%;
-    height: 600px;
+    min-height: 650px;
+    height: calc(100vh - 280px);  /* Dynamic height based on viewport */
+    max-height: 1000px;
     border: 3px solid #fbb500;
-    border-radius: 8px;
+    border-radius: 0;
     background-color: #ffffff;
     overflow: hidden;
 }
@@ -23,87 +25,117 @@
 }
 
 /* ==========================================
-   Topology Controls
+   Topology Controls - Minimal Style
    ========================================== */
 .topology-controls {
     display: flex;
-    flex-wrap: wrap;
-    gap: 10px;
     align-items: center;
-    margin-bottom: 15px;
-    padding: 10px;
-    background-color: #f5f5f5;
-    border-radius: 8px;
+    gap: 8px;
+    margin-bottom: 10px;
 }
 
 .topology-controls .button {
     margin: 0;
-    padding: 8px 15px;
-    font-size: 13px;
+    padding: 8px 16px;
+    font-size: 12px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
     background-color: #071c35;
     color: #ffffff;
-    border: none;
-    border-radius: 4px;
+    border: 1px solid #071c35;
+    border-radius: 0;
     cursor: pointer;
-    transition: background-color 0.2s;
+    transition: all 0.2s;
 }
 
 .topology-controls .button:hover {
-    background-color: #0a2548;
+    background-color: #fbb500;
+    border-color: #fbb500;
+    color: #071c35;
 }
 
 .topology-controls .button.active {
     background-color: #fbb500;
+    border-color: #fbb500;
     color: #071c35;
 }
 
 .topology-controls .button i {
-    margin-right: 5px;
+    margin-right: 6px;
 }
 
-/* Filter Controls */
+/* Filter Controls - Styled to match ATL theme */
 #filter-controls {
     display: flex;
-    flex-wrap: wrap;
-    gap: 10px;
     align-items: center;
-    flex: 1;
+    gap: 8px;
+    margin-left: auto;
 }
 
 #filter-controls input[type="text"] {
     padding: 8px 12px;
-    border: 2px solid #ddd;
-    border-radius: 4px;
-    font-size: 13px;
-    width: 180px;
-    transition: border-color 0.2s;
+    border: 1px solid #071c35;
+    border-radius: 0;
+    font-size: 12px;
+    font-family: "Proxima Nova", -apple-system, sans-serif;
+    width: 150px;
+    transition: border-color 0.2s, box-shadow 0.2s;
 }
 
 #filter-controls input[type="text"]:focus {
     border-color: #fbb500;
     outline: none;
+    box-shadow: 0 0 0 2px rgba(251, 181, 0, 0.2);
 }
 
 #filter-controls label {
     display: flex;
     align-items: center;
     gap: 5px;
-    font-size: 13px;
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.3px;
     color: #071c35;
     cursor: pointer;
-    padding: 5px 10px;
-    border-radius: 4px;
-    transition: background-color 0.2s;
+    padding: 6px 10px;
+    background: #071c35;
+    color: #fff;
+    border: 1px solid #071c35;
+    transition: all 0.2s;
 }
 
 #filter-controls label:hover {
-    background-color: #e8e8e8;
+    background-color: #fbb500;
+    border-color: #fbb500;
+    color: #071c35;
+}
+
+#filter-controls label:has(input:checked) {
+    background: #071c35;
+    color: #fff;
+}
+
+#filter-controls label:has(input:not(:checked)) {
+    background: #fff;
+    color: #071c35;
+    opacity: 0.6;
 }
 
 #filter-controls input[type="checkbox"] {
-    width: 16px;
-    height: 16px;
+    width: 12px;
+    height: 12px;
     accent-color: #fbb500;
+    margin: 0;
+}
+
+#filter-controls .button {
+    padding: 6px 12px;
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.3px;
 }
 
 /* Layout Selector */
@@ -428,6 +460,69 @@
 .status-dot.unknown { background-color: #808080; }
 
 /* ==========================================
+   Focus Mode Indicator
+   ========================================== */
+.focus-mode-indicator {
+    position: absolute;
+    top: 15px;
+    left: 15px;
+    z-index: 1000;
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 10px 16px;
+    background-color: #071c35;
+    color: #ffffff;
+    border: 2px solid #fbb500;
+    border-radius: 0;
+    font-family: "Proxima Nova", -apple-system, sans-serif;
+    font-size: 13px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+    animation: focusSlideIn 0.3s ease-out;
+}
+
+@keyframes focusSlideIn {
+    from {
+        opacity: 0;
+        transform: translateY(-10px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+.focus-mode-indicator .focus-label {
+    color: #ffffff;
+}
+
+.focus-mode-indicator .focus-label strong {
+    color: #fbb500;
+    font-weight: 600;
+}
+
+.focus-mode-indicator .focus-exit-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 24px;
+    height: 24px;
+    background: transparent;
+    border: 1px solid rgba(255, 255, 255, 0.3);
+    color: #fff;
+    font-size: 18px;
+    line-height: 1;
+    cursor: pointer;
+    transition: all 0.2s;
+}
+
+.focus-mode-indicator .focus-exit-btn:hover {
+    background-color: #fbb500;
+    border-color: #fbb500;
+    color: #071c35;
+}
+
+/* ==========================================
    View Toggle
    ========================================== */
 .view-toggle-container {
@@ -447,7 +542,8 @@
    ========================================== */
 @media (max-width: 768px) {
     #interactive-topology {
-        height: 400px;
+        min-height: 450px;
+        height: 500px;
     }
 
     .topology-controls {

--- a/nested-labvm/atd-docker/uilanding/src/html/css/topology.css
+++ b/nested-labvm/atd-docker/uilanding/src/html/css/topology.css
@@ -28,6 +28,7 @@
 /* Static topology gets same border style */
 #static-topology {
     border: 3px solid #071c35;
+    border-top: none;
     background-color: #ffffff;
     padding: 20px;
 }
@@ -37,6 +38,23 @@
     height: auto;
 }
 
+/* CVP Info section - navy background with white text */
+#cvp_info {
+    display: block;
+    background-color: #071c35;
+    color: #ffffff;
+    padding: 12px 15px;
+    margin-top: 0;
+    font-size: 14px;
+}
+
+#cvp_info h3 {
+    color: #fbb500;
+    margin: 0 0 5px 0;
+    font-size: 14px;
+    font-weight: 600;
+}
+
 #interactive-topology.loading {
     display: flex;
     align-items: center;
@@ -44,16 +62,18 @@
 }
 
 /* ==========================================
-   Topology Controls - Consistent Sizing
+   Topology Controls - Navy Bar with Yellow Accents
    ========================================== */
 .topology-controls {
     display: flex;
     align-items: center;
     gap: 8px;
-    margin-bottom: 10px;
+    margin-bottom: 0;
+    padding: 12px 15px;
+    background-color: #071c35;
 }
 
-/* Base button style - consistent height for all buttons */
+/* Base button style - transparent with yellow text/border */
 .topology-controls .button {
     margin: 0;
     padding: 7px 14px;
@@ -61,9 +81,9 @@
     font-weight: 600;
     text-transform: uppercase;
     letter-spacing: 0.5px;
-    background-color: #071c35;
-    color: #ffffff;
-    border: 2px solid #fbb500;
+    background-color: transparent;
+    color: #fbb500;
+    border: 1px solid rgba(251, 181, 0, 0.5);
     border-radius: 0;
     cursor: pointer;
     transition: all 0.2s;
@@ -73,12 +93,13 @@
     align-items: center;
     justify-content: center;
     box-sizing: border-box;
+    vertical-align: middle;
 }
 
 .topology-controls .button:hover {
-    background-color: #fbb500;
+    background-color: rgba(251, 181, 0, 0.15);
     border-color: #fbb500;
-    color: #071c35;
+    color: #fbb500;
 }
 
 .topology-controls .button.active {
@@ -107,10 +128,11 @@
     flex-wrap: wrap;
 }
 
-/* Search input - matches button height */
-#filter-controls input[type="text"] {
+/* Search input - navy background with white text */
+#filter-controls input[type="text"],
+#device-search {
     padding: 0 12px;
-    border: 2px solid #fbb500;
+    border: 1px solid rgba(251, 181, 0, 0.5);
     border-radius: 0;
     font-size: 12px;
     font-family: "Proxima Nova", -apple-system, sans-serif;
@@ -118,15 +140,30 @@
     height: 34px;
     box-sizing: border-box;
     transition: border-color 0.2s, box-shadow 0.2s;
+    /* Override Foundation defaults */
+    margin: 0;
+    margin-bottom: 0 !important;
+    vertical-align: middle;
+    display: inline-block;
+    line-height: 30px;
+    /* Navy background with white text */
+    background-color: #0a1929;
+    color: #ffffff;
 }
 
-#filter-controls input[type="text"]:focus {
+#filter-controls input[type="text"]::placeholder,
+#device-search::placeholder {
+    color: rgba(255, 255, 255, 0.5);
+}
+
+#filter-controls input[type="text"]:focus,
+#device-search:focus {
     border-color: #fbb500;
     outline: none;
-    box-shadow: 0 0 0 2px rgba(251, 181, 0, 0.2);
+    box-shadow: none;
 }
 
-/* Device type filter labels - consistent height */
+/* Device type filter labels - transparent with yellow text */
 #device-type-filters label {
     display: inline-flex;
     align-items: center;
@@ -138,28 +175,31 @@
     cursor: pointer;
     padding: 0 10px;
     height: 34px;
-    background: #071c35;
-    color: #fff;
-    border: 2px solid #fbb500;
+    background: transparent;
+    color: #fbb500;
+    border: 1px solid rgba(251, 181, 0, 0.5);
     transition: all 0.2s;
     box-sizing: border-box;
+    vertical-align: middle;
+    margin: 0;
 }
 
 #device-type-filters label:hover {
-    background-color: #fbb500;
+    background-color: rgba(251, 181, 0, 0.15);
     border-color: #fbb500;
-    color: #071c35;
+    color: #fbb500;
 }
 
 #device-type-filters label:has(input:checked) {
-    background: #071c35;
-    color: #fff;
+    background: transparent;
+    color: #fbb500;
+    border-color: #fbb500;
 }
 
 #device-type-filters label:has(input:not(:checked)) {
-    background: #fff;
-    color: #071c35;
-    opacity: 0.6;
+    background: transparent;
+    color: rgba(251, 181, 0, 0.4);
+    border-color: rgba(251, 181, 0, 0.3);
 }
 
 #device-type-filters input[type="checkbox"] {

--- a/nested-labvm/atd-docker/uilanding/src/html/css/topology.css
+++ b/nested-labvm/atd-docker/uilanding/src/html/css/topology.css
@@ -71,6 +71,14 @@
     align-items: center;
     gap: 8px;
     margin-left: auto;
+    flex-wrap: wrap;
+}
+
+#device-type-filters {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    flex-wrap: wrap;
 }
 
 #filter-controls input[type="text"] {
@@ -89,7 +97,7 @@
     box-shadow: 0 0 0 2px rgba(251, 181, 0, 0.2);
 }
 
-#filter-controls label {
+#device-type-filters label {
     display: flex;
     align-items: center;
     gap: 5px;
@@ -97,7 +105,6 @@
     font-weight: 600;
     text-transform: uppercase;
     letter-spacing: 0.3px;
-    color: #071c35;
     cursor: pointer;
     padding: 6px 10px;
     background: #071c35;
@@ -106,24 +113,24 @@
     transition: all 0.2s;
 }
 
-#filter-controls label:hover {
+#device-type-filters label:hover {
     background-color: #fbb500;
     border-color: #fbb500;
     color: #071c35;
 }
 
-#filter-controls label:has(input:checked) {
+#device-type-filters label:has(input:checked) {
     background: #071c35;
     color: #fff;
 }
 
-#filter-controls label:has(input:not(:checked)) {
+#device-type-filters label:has(input:not(:checked)) {
     background: #fff;
     color: #071c35;
     opacity: 0.6;
 }
 
-#filter-controls input[type="checkbox"] {
+#device-type-filters input[type="checkbox"] {
     width: 12px;
     height: 12px;
     accent-color: #fbb500;
@@ -295,6 +302,13 @@
 .tooltip-type.device-type-host { background-color: #dae0fe; color: #071c35; }
 .tooltip-type.device-type-pe { background-color: #4c5cae; }
 .tooltip-type.device-type-p { background-color: #6b7cc9; }
+.tooltip-type.device-type-ce { background-color: #4c5cae; }
+.tooltip-type.device-type-core { background-color: #071c35; }
+.tooltip-type.device-type-dci { background-color: #051431; }
+.tooltip-type.device-type-isp,
+.tooltip-type.device-type-internet { background-color: #e30909; }
+.tooltip-type.device-type-oob { background-color: #808080; }
+.tooltip-type.device-type-other { background-color: #666666; }
 
 .tooltip-body {
     padding: 10px 12px;

--- a/nested-labvm/atd-docker/uilanding/src/html/css/topology.css
+++ b/nested-labvm/atd-docker/uilanding/src/html/css/topology.css
@@ -7,10 +7,11 @@
    Container Styles
    ========================================== */
 
-/* Override white-box border for topology section */
+/* Override white-box for topology section - navy with yellow border */
 .topology .white-box {
-    border: none;
-    padding: 20px;
+    border: 2px solid #fbb500;
+    padding: 0;
+    background-color: #071c35;
 }
 
 #interactive-topology {
@@ -19,16 +20,15 @@
     min-height: 650px;
     height: calc(100vh - 280px);  /* Dynamic height based on viewport */
     max-height: 1000px;
-    border: 3px solid #071c35;
+    border: none;
     border-radius: 0;
     background-color: #ffffff;
     overflow: hidden;
 }
 
-/* Static topology gets same border style */
+/* Static topology - white background, no border (outer container has border) */
 #static-topology {
-    border: 3px solid #071c35;
-    border-top: none;
+    border: none;
     background-color: #ffffff;
     padding: 20px;
 }

--- a/nested-labvm/atd-docker/uilanding/src/html/css/topology.css
+++ b/nested-labvm/atd-docker/uilanding/src/html/css/topology.css
@@ -460,6 +460,82 @@
 .status-dot.unknown { background-color: #808080; }
 
 /* ==========================================
+   Context Menu
+   ========================================== */
+.topology-context-menu {
+    position: fixed;
+    z-index: 10001;
+    background-color: #ffffff;
+    border: 2px solid #071c35;
+    min-width: 180px;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);
+    font-family: "Proxima Nova", -apple-system, sans-serif;
+    font-size: 13px;
+    animation: contextMenuFadeIn 0.15s ease-out;
+}
+
+@keyframes contextMenuFadeIn {
+    from {
+        opacity: 0;
+        transform: scale(0.95);
+    }
+    to {
+        opacity: 1;
+        transform: scale(1);
+    }
+}
+
+.context-menu-header {
+    padding: 10px 14px;
+    background-color: #071c35;
+    color: #ffffff;
+    font-weight: 600;
+    font-size: 14px;
+    border-bottom: 2px solid #fbb500;
+}
+
+.context-menu-item {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 10px 14px;
+    cursor: pointer;
+    color: #071c35;
+    transition: all 0.15s;
+}
+
+.context-menu-item:hover {
+    background-color: #fbb500;
+    color: #071c35;
+}
+
+.context-menu-item.disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+}
+
+.context-menu-item.disabled:hover {
+    background-color: transparent;
+}
+
+.context-menu-icon {
+    font-size: 16px;
+    width: 20px;
+    text-align: center;
+}
+
+.context-menu-label {
+    flex: 1;
+    font-weight: 500;
+}
+
+.context-menu-separator {
+    height: 1px;
+    background-color: #ddd;
+    margin: 4px 0;
+}
+
+/* ==========================================
    Focus Mode Indicator
    ========================================== */
 .focus-mode-indicator {

--- a/nested-labvm/atd-docker/uilanding/src/html/css/topology.css
+++ b/nested-labvm/atd-docker/uilanding/src/html/css/topology.css
@@ -6,16 +6,35 @@
 /* ==========================================
    Container Styles
    ========================================== */
+
+/* Override white-box border for topology section */
+.topology .white-box {
+    border: none;
+    padding: 20px;
+}
+
 #interactive-topology {
     position: relative;
     width: 100%;
     min-height: 650px;
     height: calc(100vh - 280px);  /* Dynamic height based on viewport */
     max-height: 1000px;
-    border: 3px solid #fbb500;
+    border: 3px solid #071c35;
     border-radius: 0;
     background-color: #ffffff;
     overflow: hidden;
+}
+
+/* Static topology gets same border style */
+#static-topology {
+    border: 3px solid #071c35;
+    background-color: #ffffff;
+    padding: 20px;
+}
+
+#static-topology img {
+    max-width: 100%;
+    height: auto;
 }
 
 #interactive-topology.loading {
@@ -25,7 +44,7 @@
 }
 
 /* ==========================================
-   Topology Controls - Minimal Style
+   Topology Controls - Consistent Sizing
    ========================================== */
 .topology-controls {
     display: flex;
@@ -34,19 +53,26 @@
     margin-bottom: 10px;
 }
 
+/* Base button style - consistent height for all buttons */
 .topology-controls .button {
     margin: 0;
-    padding: 8px 16px;
-    font-size: 12px;
+    padding: 7px 14px;
+    font-size: 11px;
     font-weight: 600;
     text-transform: uppercase;
     letter-spacing: 0.5px;
     background-color: #071c35;
     color: #ffffff;
-    border: 1px solid #071c35;
+    border: 2px solid #fbb500;
     border-radius: 0;
     cursor: pointer;
     transition: all 0.2s;
+    height: 34px;
+    line-height: 1;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    box-sizing: border-box;
 }
 
 .topology-controls .button:hover {
@@ -81,13 +107,16 @@
     flex-wrap: wrap;
 }
 
+/* Search input - matches button height */
 #filter-controls input[type="text"] {
-    padding: 8px 12px;
-    border: 1px solid #071c35;
+    padding: 0 12px;
+    border: 2px solid #fbb500;
     border-radius: 0;
     font-size: 12px;
     font-family: "Proxima Nova", -apple-system, sans-serif;
     width: 150px;
+    height: 34px;
+    box-sizing: border-box;
     transition: border-color 0.2s, box-shadow 0.2s;
 }
 
@@ -97,8 +126,9 @@
     box-shadow: 0 0 0 2px rgba(251, 181, 0, 0.2);
 }
 
+/* Device type filter labels - consistent height */
 #device-type-filters label {
-    display: flex;
+    display: inline-flex;
     align-items: center;
     gap: 5px;
     font-size: 11px;
@@ -106,11 +136,13 @@
     text-transform: uppercase;
     letter-spacing: 0.3px;
     cursor: pointer;
-    padding: 6px 10px;
+    padding: 0 10px;
+    height: 34px;
     background: #071c35;
     color: #fff;
-    border: 1px solid #071c35;
+    border: 2px solid #fbb500;
     transition: all 0.2s;
+    box-sizing: border-box;
 }
 
 #device-type-filters label:hover {
@@ -135,14 +167,6 @@
     height: 12px;
     accent-color: #fbb500;
     margin: 0;
-}
-
-#filter-controls .button {
-    padding: 6px 12px;
-    font-size: 11px;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.3px;
 }
 
 /* Layout Selector */

--- a/nested-labvm/atd-docker/uilanding/src/html/css/topology.css
+++ b/nested-labvm/atd-docker/uilanding/src/html/css/topology.css
@@ -309,6 +309,8 @@
 .tooltip-type.device-type-isp,
 .tooltip-type.device-type-internet { background-color: #e30909; }
 .tooltip-type.device-type-oob { background-color: #808080; }
+.tooltip-type.device-type-gw { background-color: #d4a400; color: #071c35; }
+.tooltip-type.device-type-rr { background-color: #008b8b; }
 .tooltip-type.device-type-other { background-color: #666666; }
 
 .tooltip-body {

--- a/nested-labvm/atd-docker/uilanding/src/html/css/topology.css
+++ b/nested-labvm/atd-docker/uilanding/src/html/css/topology.css
@@ -1,0 +1,471 @@
+/**
+ * ATL Interactive Topology Diagram Styles
+ * Uses ATL color scheme: Navy #071c35, Yellow #fbb500
+ */
+
+/* ==========================================
+   Container Styles
+   ========================================== */
+#interactive-topology {
+    position: relative;
+    width: 100%;
+    height: 600px;
+    border: 3px solid #fbb500;
+    border-radius: 8px;
+    background-color: #ffffff;
+    overflow: hidden;
+}
+
+#interactive-topology.loading {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+/* ==========================================
+   Topology Controls
+   ========================================== */
+.topology-controls {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    align-items: center;
+    margin-bottom: 15px;
+    padding: 10px;
+    background-color: #f5f5f5;
+    border-radius: 8px;
+}
+
+.topology-controls .button {
+    margin: 0;
+    padding: 8px 15px;
+    font-size: 13px;
+    background-color: #071c35;
+    color: #ffffff;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    transition: background-color 0.2s;
+}
+
+.topology-controls .button:hover {
+    background-color: #0a2548;
+}
+
+.topology-controls .button.active {
+    background-color: #fbb500;
+    color: #071c35;
+}
+
+.topology-controls .button i {
+    margin-right: 5px;
+}
+
+/* Filter Controls */
+#filter-controls {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    align-items: center;
+    flex: 1;
+}
+
+#filter-controls input[type="text"] {
+    padding: 8px 12px;
+    border: 2px solid #ddd;
+    border-radius: 4px;
+    font-size: 13px;
+    width: 180px;
+    transition: border-color 0.2s;
+}
+
+#filter-controls input[type="text"]:focus {
+    border-color: #fbb500;
+    outline: none;
+}
+
+#filter-controls label {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+    font-size: 13px;
+    color: #071c35;
+    cursor: pointer;
+    padding: 5px 10px;
+    border-radius: 4px;
+    transition: background-color 0.2s;
+}
+
+#filter-controls label:hover {
+    background-color: #e8e8e8;
+}
+
+#filter-controls input[type="checkbox"] {
+    width: 16px;
+    height: 16px;
+    accent-color: #fbb500;
+}
+
+/* Layout Selector */
+.layout-selector {
+    display: flex;
+    gap: 5px;
+}
+
+.layout-selector .button {
+    padding: 6px 12px;
+    font-size: 12px;
+}
+
+/* ==========================================
+   Loading Indicator
+   ========================================== */
+.topology-loader {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    text-align: center;
+    z-index: 100;
+}
+
+.loader-spinner {
+    width: 50px;
+    height: 50px;
+    border: 4px solid #ddd;
+    border-top-color: #fbb500;
+    border-radius: 50%;
+    animation: spin 1s linear infinite;
+    margin: 0 auto 15px;
+}
+
+@keyframes spin {
+    to {
+        transform: rotate(360deg);
+    }
+}
+
+.loader-text {
+    font-family: "Proxima Nova", sans-serif;
+    font-size: 14px;
+    color: #071c35;
+}
+
+/* ==========================================
+   Error State
+   ========================================== */
+.topology-error {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    text-align: center;
+    padding: 30px;
+    max-width: 400px;
+}
+
+.error-icon {
+    width: 60px;
+    height: 60px;
+    line-height: 60px;
+    font-size: 30px;
+    font-weight: bold;
+    color: #ffffff;
+    background-color: #e30909;
+    border-radius: 50%;
+    margin: 0 auto 15px;
+}
+
+.error-title {
+    font-size: 18px;
+    font-weight: 600;
+    color: #071c35;
+    margin-bottom: 10px;
+}
+
+.error-message {
+    font-size: 14px;
+    color: #666;
+    margin-bottom: 20px;
+}
+
+.error-retry {
+    padding: 10px 25px;
+    background-color: #fbb500;
+    color: #071c35;
+    border: none;
+    border-radius: 4px;
+    font-size: 14px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background-color 0.2s;
+}
+
+.error-retry:hover {
+    background-color: #e5a600;
+}
+
+/* ==========================================
+   Tooltip Styles
+   ========================================== */
+.topology-tooltip {
+    position: fixed;
+    z-index: 10000;
+    background-color: #ffffff;
+    border: 2px solid #071c35;
+    border-radius: 8px;
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15);
+    font-family: "Proxima Nova", -apple-system, sans-serif;
+    font-size: 13px;
+    max-width: 300px;
+    pointer-events: none;
+    animation: tooltipFadeIn 0.15s ease-out;
+}
+
+@keyframes tooltipFadeIn {
+    from {
+        opacity: 0;
+        transform: translateY(-5px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+.tooltip-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 10px 12px;
+    background-color: #071c35;
+    color: #ffffff;
+    border-radius: 6px 6px 0 0;
+}
+
+.tooltip-header strong {
+    font-size: 14px;
+    font-weight: 600;
+}
+
+.tooltip-type {
+    font-size: 10px;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    padding: 3px 8px;
+    border-radius: 10px;
+    background-color: rgba(255, 255, 255, 0.2);
+}
+
+.tooltip-type.device-type-spine { background-color: #4c5cae; }
+.tooltip-type.device-type-leaf { background-color: #78d82c; color: #071c35; }
+.tooltip-type.device-type-borderleaf { background-color: #fbb500; color: #071c35; }
+.tooltip-type.device-type-host { background-color: #dae0fe; color: #071c35; }
+.tooltip-type.device-type-pe { background-color: #4c5cae; }
+.tooltip-type.device-type-p { background-color: #6b7cc9; }
+
+.tooltip-body {
+    padding: 10px 12px;
+}
+
+.tooltip-row {
+    display: flex;
+    justify-content: space-between;
+    padding: 4px 0;
+    border-bottom: 1px solid #eee;
+}
+
+.tooltip-row:last-child {
+    border-bottom: none;
+}
+
+.tooltip-label {
+    font-weight: 500;
+    color: #666;
+}
+
+.tooltip-value {
+    font-family: "Monaco", "Consolas", monospace;
+    font-size: 12px;
+    color: #071c35;
+}
+
+.tooltip-value.status-up { color: #78d82c; }
+.tooltip-value.status-down { color: #e30909; }
+.tooltip-value.status-init { color: #fbb500; }
+.tooltip-value.status-unknown { color: #808080; }
+
+.tooltip-ports {
+    margin-top: 10px;
+    padding-top: 10px;
+    border-top: 1px dashed #ddd;
+}
+
+.tooltip-ports strong {
+    display: block;
+    margin-bottom: 5px;
+    color: #071c35;
+}
+
+.tooltip-ports ul {
+    margin: 0;
+    padding: 0 0 0 15px;
+    font-size: 11px;
+}
+
+.tooltip-ports li {
+    padding: 2px 0;
+    font-family: "Monaco", "Consolas", monospace;
+}
+
+.tooltip-ports em {
+    display: block;
+    margin-top: 5px;
+    color: #999;
+    font-size: 11px;
+}
+
+.tooltip-footer {
+    padding: 8px 12px;
+    background-color: #f8f8f8;
+    border-radius: 0 0 6px 6px;
+    font-size: 11px;
+    color: #888;
+    text-align: center;
+    font-style: italic;
+}
+
+/* Edge Tooltip */
+.topology-tooltip.edge-tooltip .tooltip-header {
+    background-color: #4c5cae;
+}
+
+/* ==========================================
+   Legend
+   ========================================== */
+.topology-legend {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 15px;
+    padding: 10px 15px;
+    background-color: #f8f8f8;
+    border-radius: 8px;
+    margin-top: 15px;
+}
+
+.legend-item {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 12px;
+    color: #071c35;
+}
+
+.legend-shape {
+    width: 20px;
+    height: 20px;
+    border: 2px solid #071c35;
+}
+
+.legend-shape.spine {
+    background-color: #4c5cae;
+    transform: rotate(45deg);
+    width: 16px;
+    height: 16px;
+}
+
+.legend-shape.leaf {
+    background-color: #78d82c;
+    border-radius: 4px;
+}
+
+.legend-shape.borderleaf {
+    background-color: #fbb500;
+    clip-path: polygon(50% 0%, 100% 25%, 100% 75%, 50% 100%, 0% 75%, 0% 25%);
+}
+
+.legend-shape.host {
+    background-color: #dae0fe;
+    border-radius: 50%;
+}
+
+.legend-shape.pe {
+    background-color: #4c5cae;
+    transform: rotate(45deg);
+    width: 14px;
+    height: 14px;
+}
+
+/* ==========================================
+   Status Bar
+   ========================================== */
+.topology-status-bar {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 8px 15px;
+    background-color: #071c35;
+    color: #ffffff;
+    border-radius: 0 0 8px 8px;
+    font-size: 12px;
+}
+
+.status-item {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+}
+
+.status-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+}
+
+.status-dot.up { background-color: #78d82c; }
+.status-dot.down { background-color: #e30909; }
+.status-dot.init { background-color: #fbb500; }
+.status-dot.unknown { background-color: #808080; }
+
+/* ==========================================
+   View Toggle
+   ========================================== */
+.view-toggle-container {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin-bottom: 10px;
+}
+
+.view-toggle-label {
+    font-size: 13px;
+    color: #071c35;
+}
+
+/* ==========================================
+   Responsive Adjustments
+   ========================================== */
+@media (max-width: 768px) {
+    #interactive-topology {
+        height: 400px;
+    }
+
+    .topology-controls {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    #filter-controls {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    #filter-controls input[type="text"] {
+        width: 100%;
+    }
+
+    .topology-tooltip {
+        max-width: 250px;
+        font-size: 12px;
+    }
+}

--- a/nested-labvm/atd-docker/uilanding/src/html/index.html
+++ b/nested-labvm/atd-docker/uilanding/src/html/index.html
@@ -451,12 +451,13 @@
       'pe': 'PE Routers',
       'p': 'P Routers',
       'ce': 'CE Routers',
+      'customer': 'Customer',
       'core': 'Core',
       'dci': 'DCI',
       'isp': 'ISP',
       'internet': 'Internet',
       'oob': 'OOB',
-      'other': 'Devices'
+      'other': 'Other'
     };
 
     // Build dynamic filter checkboxes based on device types in topology

--- a/nested-labvm/atd-docker/uilanding/src/html/index.html
+++ b/nested-labvm/atd-docker/uilanding/src/html/index.html
@@ -191,7 +191,7 @@
                     <div id="filter-controls" style="display: none;">
                       <input type="text" id="device-search" placeholder="Search devices..." />
                       <label><input type="checkbox" checked data-filter="spine"> Spines</label>
-                      <label><input type="checkbox" checked data-filter="leaf"> Leaves</label>
+                      <label><input type="checkbox" checked data-filter="leaf"> Leafs</label>
                       <label><input type="checkbox" checked data-filter="host"> Hosts</label>
                       <label><input type="checkbox" checked data-filter="pe"> PE</label>
                       <label><input type="checkbox" checked data-filter="p"> P</label>
@@ -477,6 +477,7 @@
       if (resetBtn) {
         resetBtn.addEventListener('click', function() {
           if (topoManager) {
+            topoManager.clearHighlights();    // Exit focus mode and clear highlights
             topoManager.setLayout('preset');  // Reset to organized layout
             topoManager.resetFilters();
             document.querySelectorAll('#filter-controls input[type="checkbox"]').forEach(cb => cb.checked = true);

--- a/nested-labvm/atd-docker/uilanding/src/html/index.html
+++ b/nested-labvm/atd-docker/uilanding/src/html/index.html
@@ -190,11 +190,7 @@
                     </button>
                     <div id="filter-controls" style="display: none;">
                       <input type="text" id="device-search" placeholder="Search devices..." />
-                      <label><input type="checkbox" checked data-filter="spine"> Spines</label>
-                      <label><input type="checkbox" checked data-filter="leaf"> Leafs</label>
-                      <label><input type="checkbox" checked data-filter="host"> Hosts</label>
-                      <label><input type="checkbox" checked data-filter="pe"> PE</label>
-                      <label><input type="checkbox" checked data-filter="p"> P</label>
+                      <div id="device-type-filters"></div>
                       <button id="reset-layout" class="button">Reset Layout</button>
                       <button id="fit-view" class="button">Fit View</button>
                     </div>
@@ -446,17 +442,61 @@
       }
     });
 
+    // Device type display names
+    const deviceTypeNames = {
+      'spine': 'Spines',
+      'leaf': 'Leafs',
+      'borderleaf': 'Borderleafs',
+      'host': 'Hosts',
+      'pe': 'PE Routers',
+      'p': 'P Routers',
+      'ce': 'CE Routers',
+      'core': 'Core',
+      'dci': 'DCI',
+      'isp': 'ISP',
+      'internet': 'Internet',
+      'oob': 'OOB',
+      'other': 'Devices'
+    };
+
+    // Build dynamic filter checkboxes based on device types in topology
+    function buildFilterCheckboxes() {
+      const filtersContainer = document.getElementById('device-type-filters');
+      if (!filtersContainer || !topoManager) return;
+
+      // Get device type counts from topology
+      const counts = topoManager.getDeviceTypeCounts();
+
+      // Clear existing checkboxes
+      filtersContainer.innerHTML = '';
+
+      // Create checkbox for each device type that exists
+      Object.keys(counts).forEach(deviceType => {
+        if (counts[deviceType] > 0) {
+          const label = document.createElement('label');
+          const checkbox = document.createElement('input');
+          checkbox.type = 'checkbox';
+          checkbox.checked = true;
+          checkbox.dataset.filter = deviceType;
+
+          checkbox.addEventListener('change', function() {
+            if (topoManager) {
+              topoManager.toggleDeviceType(deviceType);
+            }
+          });
+
+          const displayName = deviceTypeNames[deviceType] || deviceType;
+          label.appendChild(checkbox);
+          label.appendChild(document.createTextNode(` ${displayName}`));
+          filtersContainer.appendChild(label);
+        }
+      });
+    }
+
     // Setup filter controls
     function setupFilters() {
-      // Device type filter checkboxes
-      document.querySelectorAll('#filter-controls input[type="checkbox"]').forEach(checkbox => {
-        checkbox.addEventListener('change', function() {
-          const filterType = this.dataset.filter;
-          if (topoManager && filterType) {
-            topoManager.toggleDeviceType(filterType);
-          }
-        });
-      });
+      // Build dynamic checkboxes
+      buildFilterCheckboxes();
 
       // Search input
       const searchInput = document.getElementById('device-search');
@@ -480,7 +520,7 @@
             topoManager.clearHighlights();    // Exit focus mode and clear highlights
             topoManager.setLayout('preset');  // Reset to organized layout
             topoManager.resetFilters();
-            document.querySelectorAll('#filter-controls input[type="checkbox"]').forEach(cb => cb.checked = true);
+            document.querySelectorAll('#device-type-filters input[type="checkbox"]').forEach(cb => cb.checked = true);
             document.getElementById('device-search').value = '';
           }
         });

--- a/nested-labvm/atd-docker/uilanding/src/html/index.html
+++ b/nested-labvm/atd-docker/uilanding/src/html/index.html
@@ -186,9 +186,9 @@
                   <!-- View Toggle -->
                   <div class="topology-controls">
                     <button id="toggle-topo-view" class="button">
-                      <i class="fa-solid fa-diagram-project"></i> Switch to Interactive
+                      <i class="fa-solid fa-image"></i> Switch to Static
                     </button>
-                    <div id="filter-controls" style="display: none;">
+                    <div id="filter-controls">
                       <input type="text" id="device-search" placeholder="Search devices..." />
                       <div id="device-type-filters"></div>
                       <button id="reset-layout" class="button">Reset Layout</button>
@@ -196,13 +196,13 @@
                     </div>
                   </div>
 
-                  <!-- Static Topology (default view) -->
-                  <div id="static-topology" class="text-center">
+                  <!-- Static Topology (hidden by default) -->
+                  <div id="static-topology" class="text-center" style="display: none;">
                     <img src="topo/atd-topo.png" usemap="#image_map" />
                   </div>
 
-                  <!-- Interactive Topology (hidden by default) -->
-                  <div id="interactive-topology" style="display: none;"></div>
+                  <!-- Interactive Topology (default view) -->
+                  <div id="interactive-topology"></div>
 
                   {% if topo_cvp %}
                   <span id="cvp_info"></span>
@@ -396,7 +396,28 @@
     import { TopologyManager } from './js/topology/topology-manager.js';
 
     let topoManager = null;
-    let isInteractiveView = false;
+    let isInteractiveView = true;  // Start with interactive view
+
+    // Initialize topology on page load
+    async function initTopology() {
+      try {
+        topoManager = new TopologyManager('interactive-topology', {
+          apiUrl: '/td-api/topology',
+          layout: 'preset',  // Use server-calculated positions for organized layout
+          enableStatus: true,
+          enableFilters: true
+        });
+        await topoManager.init();
+
+        // Setup filter checkboxes
+        setupFilters();
+      } catch (error) {
+        console.error('Failed to initialize topology:', error);
+      }
+    }
+
+    // Initialize on DOM ready
+    initTopology();
 
     // Toggle between static and interactive views
     document.getElementById('toggle-topo-view').addEventListener('click', async function() {
@@ -405,33 +426,7 @@
       const filterControls = document.getElementById('filter-controls');
       const toggleBtn = this;
 
-      if (!isInteractiveView) {
-        // Switch to interactive view
-        staticDiv.style.display = 'none';
-        interactiveDiv.style.display = 'block';
-        filterControls.style.display = 'flex';
-        toggleBtn.innerHTML = '<i class="fa-solid fa-image"></i> Switch to Static';
-
-        // Initialize topology manager if not already done
-        if (!topoManager) {
-          try {
-            topoManager = new TopologyManager('interactive-topology', {
-              apiUrl: '/td-api/topology',
-              layout: 'preset',  // Use server-calculated positions for organized layout
-              enableStatus: true,
-              enableFilters: true
-            });
-            await topoManager.init();
-
-            // Setup filter checkboxes
-            setupFilters();
-          } catch (error) {
-            console.error('Failed to initialize topology:', error);
-          }
-        }
-
-        isInteractiveView = true;
-      } else {
+      if (isInteractiveView) {
         // Switch to static view
         staticDiv.style.display = 'block';
         interactiveDiv.style.display = 'none';
@@ -439,6 +434,19 @@
         toggleBtn.innerHTML = '<i class="fa-solid fa-diagram-project"></i> Switch to Interactive';
 
         isInteractiveView = false;
+      } else {
+        // Switch to interactive view
+        staticDiv.style.display = 'none';
+        interactiveDiv.style.display = 'block';
+        filterControls.style.display = 'flex';
+        toggleBtn.innerHTML = '<i class="fa-solid fa-image"></i> Switch to Static';
+
+        // Re-fit view when switching back
+        if (topoManager) {
+          topoManager.fit();
+        }
+
+        isInteractiveView = true;
       }
     });
 

--- a/nested-labvm/atd-docker/uilanding/src/html/index.html
+++ b/nested-labvm/atd-docker/uilanding/src/html/index.html
@@ -421,7 +421,7 @@
           try {
             topoManager = new TopologyManager('interactive-topology', {
               apiUrl: '/td-api/topology',
-              layout: 'dagre',
+              layout: 'preset',  // Use server-calculated positions for organized layout
               enableStatus: true,
               enableFilters: true
             });
@@ -477,7 +477,7 @@
       if (resetBtn) {
         resetBtn.addEventListener('click', function() {
           if (topoManager) {
-            topoManager.setLayout('dagre');
+            topoManager.setLayout('preset');  // Reset to organized layout
             topoManager.resetFilters();
             document.querySelectorAll('#filter-controls input[type="checkbox"]').forEach(cb => cb.checked = true);
             document.getElementById('device-search').value = '';

--- a/nested-labvm/atd-docker/uilanding/src/html/index.html
+++ b/nested-labvm/atd-docker/uilanding/src/html/index.html
@@ -13,6 +13,7 @@
   <link rel="stylesheet" href="css/overlay.css">
   <link rel="stylesheet" href="css/style.css" />
   <link rel="stylesheet" href="css/home.css" />
+  <link rel="stylesheet" href="css/topology.css" />
 </head>
 
 <body>
@@ -181,21 +182,32 @@
             <!---==============-->
             <section class="topology">
               <div class="topology-overview">
-                <div class="white-box text-center">
-                  <!-- <h2>Click on a device to access CLI.</h2> -->
-                  <img src="topo/atd-topo.png" usemap="#image_map" />
-                  <!--  <map name="image_map">
-                        {% for node in NODES %}
-                        {% if node == "CVP" %}
-                            <area alt="{{ escape(node) }}" title="{{ escape(node) }}" href="/cv" target="_blank" coords="{{ escape(NODES[node]['coords']) }}" shape="rect">
-                        {% else %}
-                            <area alt="{{ escape(node) }}" title="{{ escape(node) }}" href="/ssh/host/{{ escape(NODES[node]['ip']) }}" target="_blank" coords="{{ escape(NODES[node]['coords']) }}" shape="rect">
-                        {% end %}
-                        {% end %}
-                        {% for gui_url in zip(GUI_URLS,SERVERS) %}
-                            <area alt="{{ escape(gui_url[1]) }}" title="{{ escape(gui_url[1]) }}" href="{{gui_url[0]}}" target="_blank" coords="{{ escape(SERVERS[gui_url[1]]['coords']) }}" shape="rect">
-                        {% end %}
-                    </map> -->
+                <div class="white-box">
+                  <!-- View Toggle -->
+                  <div class="topology-controls">
+                    <button id="toggle-topo-view" class="button">
+                      <i class="fa-solid fa-diagram-project"></i> Switch to Interactive
+                    </button>
+                    <div id="filter-controls" style="display: none;">
+                      <input type="text" id="device-search" placeholder="Search devices..." />
+                      <label><input type="checkbox" checked data-filter="spine"> Spines</label>
+                      <label><input type="checkbox" checked data-filter="leaf"> Leaves</label>
+                      <label><input type="checkbox" checked data-filter="host"> Hosts</label>
+                      <label><input type="checkbox" checked data-filter="pe"> PE</label>
+                      <label><input type="checkbox" checked data-filter="p"> P</label>
+                      <button id="reset-layout" class="button">Reset Layout</button>
+                      <button id="fit-view" class="button">Fit View</button>
+                    </div>
+                  </div>
+
+                  <!-- Static Topology (default view) -->
+                  <div id="static-topology" class="text-center">
+                    <img src="topo/atd-topo.png" usemap="#image_map" />
+                  </div>
+
+                  <!-- Interactive Topology (hidden by default) -->
+                  <div id="interactive-topology" style="display: none;"></div>
+
                   {% if topo_cvp %}
                   <span id="cvp_info"></span>
                   <br /><br />
@@ -377,6 +389,113 @@
   <script src="js/backend.js"></script>
   <script type="module" src="js/honorlock-examsubmit-v1.js"></script>
   <script src="js/connectivity-monitor.js"></script>
+
+  <!-- Cytoscape.js for Interactive Topology -->
+  <script src="https://unpkg.com/cytoscape@3.28.1/dist/cytoscape.min.js"></script>
+  <script src="https://unpkg.com/dagre@0.8.5/dist/dagre.min.js"></script>
+  <script src="https://unpkg.com/cytoscape-dagre@2.5.0/cytoscape-dagre.js"></script>
+
+  <!-- Interactive Topology Initialization -->
+  <script type="module">
+    import { TopologyManager } from './js/topology/topology-manager.js';
+
+    let topoManager = null;
+    let isInteractiveView = false;
+
+    // Toggle between static and interactive views
+    document.getElementById('toggle-topo-view').addEventListener('click', async function() {
+      const staticDiv = document.getElementById('static-topology');
+      const interactiveDiv = document.getElementById('interactive-topology');
+      const filterControls = document.getElementById('filter-controls');
+      const toggleBtn = this;
+
+      if (!isInteractiveView) {
+        // Switch to interactive view
+        staticDiv.style.display = 'none';
+        interactiveDiv.style.display = 'block';
+        filterControls.style.display = 'flex';
+        toggleBtn.innerHTML = '<i class="fa-solid fa-image"></i> Switch to Static';
+
+        // Initialize topology manager if not already done
+        if (!topoManager) {
+          try {
+            topoManager = new TopologyManager('interactive-topology', {
+              apiUrl: '/td-api/topology',
+              layout: 'dagre',
+              enableStatus: true,
+              enableFilters: true
+            });
+            await topoManager.init();
+
+            // Setup filter checkboxes
+            setupFilters();
+          } catch (error) {
+            console.error('Failed to initialize topology:', error);
+          }
+        }
+
+        isInteractiveView = true;
+      } else {
+        // Switch to static view
+        staticDiv.style.display = 'block';
+        interactiveDiv.style.display = 'none';
+        filterControls.style.display = 'none';
+        toggleBtn.innerHTML = '<i class="fa-solid fa-diagram-project"></i> Switch to Interactive';
+
+        isInteractiveView = false;
+      }
+    });
+
+    // Setup filter controls
+    function setupFilters() {
+      // Device type filter checkboxes
+      document.querySelectorAll('#filter-controls input[type="checkbox"]').forEach(checkbox => {
+        checkbox.addEventListener('change', function() {
+          const filterType = this.dataset.filter;
+          if (topoManager && filterType) {
+            topoManager.toggleDeviceType(filterType);
+          }
+        });
+      });
+
+      // Search input
+      const searchInput = document.getElementById('device-search');
+      if (searchInput) {
+        let searchTimeout;
+        searchInput.addEventListener('input', function() {
+          clearTimeout(searchTimeout);
+          searchTimeout = setTimeout(() => {
+            if (topoManager) {
+              topoManager.search(this.value);
+            }
+          }, 300);
+        });
+      }
+
+      // Reset layout button
+      const resetBtn = document.getElementById('reset-layout');
+      if (resetBtn) {
+        resetBtn.addEventListener('click', function() {
+          if (topoManager) {
+            topoManager.setLayout('dagre');
+            topoManager.resetFilters();
+            document.querySelectorAll('#filter-controls input[type="checkbox"]').forEach(cb => cb.checked = true);
+            document.getElementById('device-search').value = '';
+          }
+        });
+      }
+
+      // Fit view button
+      const fitBtn = document.getElementById('fit-view');
+      if (fitBtn) {
+        fitBtn.addEventListener('click', function() {
+          if (topoManager) {
+            topoManager.fit();
+          }
+        });
+      }
+    }
+  </script>
 </body>
 
 </html>

--- a/nested-labvm/atd-docker/uilanding/src/html/js/topology/cytoscape-styles.js
+++ b/nested-labvm/atd-docker/uilanding/src/html/js/topology/cytoscape-styles.js
@@ -221,9 +221,9 @@ export function getCytoscapeStyles() {
                 'font-family': '"Proxima Nova", sans-serif',
                 'text-rotation': 'autorotate',
                 'text-margin-y': -10,
-                'color': '#666666',
+                'color': '#333333',
                 'text-outline-color': '#ffffff',
-                'text-outline-width': 1
+                'text-outline-width': 2
             }
         },
 

--- a/nested-labvm/atd-docker/uilanding/src/html/js/topology/cytoscape-styles.js
+++ b/nested-labvm/atd-docker/uilanding/src/html/js/topology/cytoscape-styles.js
@@ -106,6 +106,16 @@ export function getCytoscapeStyles() {
             }
         },
         {
+            selector: '.device-type-ce',
+            style: {
+                'shape': 'round-rectangle',
+                'background-color': '#4c5cae',
+                'border-color': '#071c35',
+                'width': 45,
+                'height': 45
+            }
+        },
+        {
             selector: '.device-type-dci',
             style: {
                 'shape': 'octagon',

--- a/nested-labvm/atd-docker/uilanding/src/html/js/topology/cytoscape-styles.js
+++ b/nested-labvm/atd-docker/uilanding/src/html/js/topology/cytoscape-styles.js
@@ -116,6 +116,16 @@ export function getCytoscapeStyles() {
             }
         },
         {
+            selector: '.device-type-customer',
+            style: {
+                'shape': 'round-rectangle',
+                'background-color': '#78d82c',
+                'border-color': '#071c35',
+                'width': 45,
+                'height': 45
+            }
+        },
+        {
             selector: '.device-type-dci',
             style: {
                 'shape': 'octagon',

--- a/nested-labvm/atd-docker/uilanding/src/html/js/topology/cytoscape-styles.js
+++ b/nested-labvm/atd-docker/uilanding/src/html/js/topology/cytoscape-styles.js
@@ -264,6 +264,20 @@ export function getCytoscapeStyles() {
                 'width': 3,
                 'opacity': 1
             }
+        },
+
+        // ==========================================
+        // Focus Mode States (right-click to focus)
+        // ==========================================
+        {
+            selector: 'node.focused',
+            style: {
+                'border-color': '#fbb500',
+                'border-width': 5,
+                'z-index': 9999,
+                'font-size': 14,
+                'font-weight': 700
+            }
         }
     ];
 }

--- a/nested-labvm/atd-docker/uilanding/src/html/js/topology/cytoscape-styles.js
+++ b/nested-labvm/atd-docker/uilanding/src/html/js/topology/cytoscape-styles.js
@@ -157,6 +157,27 @@ export function getCytoscapeStyles() {
             }
         },
         {
+            selector: '.device-type-gw',
+            style: {
+                'shape': 'pentagon',
+                'background-color': '#d4a400',
+                'border-color': '#071c35',
+                'width': 55,
+                'height': 55
+            }
+        },
+        {
+            selector: '.device-type-rr',
+            style: {
+                'shape': 'star',
+                'background-color': '#008b8b',
+                'border-color': '#071c35',
+                'color': '#ffffff',
+                'width': 60,
+                'height': 60
+            }
+        },
+        {
             selector: '.device-type-other',
             style: {
                 'shape': 'rectangle',

--- a/nested-labvm/atd-docker/uilanding/src/html/js/topology/cytoscape-styles.js
+++ b/nested-labvm/atd-docker/uilanding/src/html/js/topology/cytoscape-styles.js
@@ -1,0 +1,269 @@
+/**
+ * Cytoscape.js Styles for ATL Topology Diagram
+ * Uses ATL color scheme: Navy #071c35, Yellow #fbb500
+ */
+
+export function getCytoscapeStyles() {
+    return [
+        // ==========================================
+        // Node Base Styles
+        // ==========================================
+        {
+            selector: 'node',
+            style: {
+                'label': 'data(label)',
+                'text-valign': 'bottom',
+                'text-halign': 'center',
+                'text-margin-y': 8,
+                'font-family': '"Proxima Nova", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
+                'font-size': 11,
+                'font-weight': 500,
+                'color': '#071c35',
+                'text-outline-color': '#ffffff',
+                'text-outline-width': 2,
+                'border-width': 2,
+                'border-color': '#071c35',
+                'background-color': '#ffffff',
+                'width': 50,
+                'height': 50,
+                'transition-property': 'border-color, border-width, background-color, opacity',
+                'transition-duration': '0.2s'
+            }
+        },
+
+        // ==========================================
+        // Device Type Styles
+        // ==========================================
+        {
+            selector: '.device-type-spine',
+            style: {
+                'shape': 'diamond',
+                'background-color': '#4c5cae',
+                'border-color': '#071c35',
+                'width': 60,
+                'height': 60
+            }
+        },
+        {
+            selector: '.device-type-leaf',
+            style: {
+                'shape': 'round-rectangle',
+                'background-color': '#78d82c',
+                'border-color': '#071c35',
+                'width': 50,
+                'height': 50
+            }
+        },
+        {
+            selector: '.device-type-borderleaf',
+            style: {
+                'shape': 'hexagon',
+                'background-color': '#fbb500',
+                'border-color': '#071c35',
+                'width': 55,
+                'height': 55
+            }
+        },
+        {
+            selector: '.device-type-host',
+            style: {
+                'shape': 'ellipse',
+                'background-color': '#dae0fe',
+                'border-color': '#4c5cae',
+                'width': 45,
+                'height': 45
+            }
+        },
+        {
+            selector: '.device-type-core',
+            style: {
+                'shape': 'triangle',
+                'background-color': '#071c35',
+                'border-color': '#fbb500',
+                'color': '#ffffff',
+                'width': 55,
+                'height': 55
+            }
+        },
+        {
+            selector: '.device-type-pe',
+            style: {
+                'shape': 'diamond',
+                'background-color': '#4c5cae',
+                'border-color': '#071c35',
+                'width': 55,
+                'height': 55
+            }
+        },
+        {
+            selector: '.device-type-p',
+            style: {
+                'shape': 'diamond',
+                'background-color': '#6b7cc9',
+                'border-color': '#071c35',
+                'width': 50,
+                'height': 50
+            }
+        },
+        {
+            selector: '.device-type-dci',
+            style: {
+                'shape': 'octagon',
+                'background-color': '#051431',
+                'border-color': '#fbb500',
+                'color': '#ffffff',
+                'width': 55,
+                'height': 55
+            }
+        },
+        {
+            selector: '.device-type-isp, .device-type-internet',
+            style: {
+                'shape': 'star',
+                'background-color': '#e30909',
+                'border-color': '#071c35',
+                'width': 60,
+                'height': 60
+            }
+        },
+        {
+            selector: '.device-type-oob',
+            style: {
+                'shape': 'round-rectangle',
+                'background-color': '#808080',
+                'border-color': '#071c35',
+                'width': 45,
+                'height': 45
+            }
+        },
+        {
+            selector: '.device-type-other',
+            style: {
+                'shape': 'rectangle',
+                'background-color': '#666666',
+                'border-color': '#071c35',
+                'width': 45,
+                'height': 45
+            }
+        },
+
+        // ==========================================
+        // Status Styles
+        // ==========================================
+        {
+            selector: '.status-up',
+            style: {
+                'border-color': '#78d82c',
+                'border-width': 3
+            }
+        },
+        {
+            selector: '.status-down',
+            style: {
+                'border-color': '#e30909',
+                'border-width': 4,
+                'opacity': 0.7
+            }
+        },
+        {
+            selector: '.status-init',
+            style: {
+                'border-color': '#fbb500',
+                'border-width': 3
+            }
+        },
+        {
+            selector: '.status-unknown',
+            style: {
+                'border-style': 'dashed'
+            }
+        },
+
+        // ==========================================
+        // Edge Styles
+        // ==========================================
+        {
+            selector: 'edge',
+            style: {
+                'width': 2,
+                'line-color': '#071c35',
+                'curve-style': 'bezier',
+                'opacity': 0.7,
+                'transition-property': 'line-color, width, opacity',
+                'transition-duration': '0.2s'
+            }
+        },
+        {
+            selector: 'edge[label]',
+            style: {
+                'label': 'data(label)',
+                'font-size': 9,
+                'font-family': '"Proxima Nova", sans-serif',
+                'text-rotation': 'autorotate',
+                'text-margin-y': -10,
+                'color': '#666666',
+                'text-outline-color': '#ffffff',
+                'text-outline-width': 1
+            }
+        },
+
+        // ==========================================
+        // Interactive States
+        // ==========================================
+        {
+            selector: 'node:selected',
+            style: {
+                'border-color': '#fbb500',
+                'border-width': 4,
+                'box-shadow': '0 0 10px #fbb500'
+            }
+        },
+        {
+            selector: 'node.highlighted',
+            style: {
+                'border-color': '#fbb500',
+                'border-width': 4,
+                'z-index': 999
+            }
+        },
+        {
+            selector: 'edge.highlighted',
+            style: {
+                'line-color': '#fbb500',
+                'width': 4,
+                'opacity': 1,
+                'z-index': 998
+            }
+        },
+        {
+            selector: 'node.faded',
+            style: {
+                'opacity': 0.3
+            }
+        },
+        {
+            selector: 'edge.faded',
+            style: {
+                'opacity': 0.15
+            }
+        },
+
+        // ==========================================
+        // Hover States (for visual feedback)
+        // ==========================================
+        {
+            selector: 'node.hover',
+            style: {
+                'border-width': 3,
+                'z-index': 999
+            }
+        },
+        {
+            selector: 'edge.hover',
+            style: {
+                'width': 3,
+                'opacity': 1
+            }
+        }
+    ];
+}

--- a/nested-labvm/atd-docker/uilanding/src/html/js/topology/event-handlers.js
+++ b/nested-labvm/atd-docker/uilanding/src/html/js/topology/event-handlers.js
@@ -8,11 +8,14 @@ export class EventManager {
         this.cy = cy;
         this.container = container;
         this.tooltip = null;
+        this.contextMenu = null;
         this.focusMode = false;
         this.focusedNode = null;
+        this.terminalWindow = null;  // Reference to terminal window for tab reuse
 
         // Store bound handler reference for proper cleanup (prevents memory leak)
         this.boundKeyDownHandler = (evt) => this.handleKeyDown(evt);
+        this.boundClickHandler = (evt) => this.handleDocumentClick(evt);
 
         this.registerHandlers();
     }
@@ -21,11 +24,11 @@ export class EventManager {
      * Register all event handlers
      */
     registerHandlers() {
-        // Node click - open SSH
-        this.cy.on('tap', 'node', (evt) => this.handleNodeClick(evt));
+        // Node click - open SSH (removed - now via context menu)
+        // this.cy.on('tap', 'node', (evt) => this.handleNodeClick(evt));
 
-        // Node right-click - focus mode
-        this.cy.on('cxttap', 'node', (evt) => this.handleNodeRightClick(evt));
+        // Node right-click - show context menu
+        this.cy.on('cxttap', 'node', (evt) => this.showContextMenu(evt));
 
         // Node hover - show tooltip (only when not in focus mode)
         this.cy.on('mouseover', 'node', (evt) => this.handleNodeMouseOver(evt));
@@ -38,6 +41,7 @@ export class EventManager {
         // Background click - clear selections and exit focus mode
         this.cy.on('tap', (evt) => {
             if (evt.target === this.cy) {
+                this.hideContextMenu();
                 this.exitFocusMode();
                 this.clearHighlights();
             }
@@ -50,30 +54,179 @@ export class EventManager {
 
         // Keyboard shortcuts (using stored reference for cleanup)
         document.addEventListener('keydown', this.boundKeyDownHandler);
+
+        // Click anywhere to close context menu
+        document.addEventListener('click', this.boundClickHandler);
     }
 
     /**
-     * Handle node click - open SSH session in terminal page
+     * Handle clicks on document to close context menu
      */
-    handleNodeClick(evt) {
-        const node = evt.target;
-        const ip = node.data('ip');
-        const deviceName = node.data('label');
-
-        if (ip && ip !== 'N/A') {
-            // Navigate to terminal page with device parameters
-            const terminalUrl = `/terminal?device=${encodeURIComponent(deviceName)}&ip=${encodeURIComponent(ip)}`;
-            window.open(terminalUrl, 'terminal-page');
+    handleDocumentClick(evt) {
+        if (this.contextMenu && !this.contextMenu.contains(evt.target)) {
+            this.hideContextMenu();
         }
     }
 
     /**
-     * Handle node right-click - enter focus mode
-     * Zooms to the node and highlights only its connections
+     * Open SSH session in terminal page
+     * Uses postMessage to communicate with existing terminal window
      */
-    handleNodeRightClick(evt) {
-        const node = evt.target;
+    openTerminal(deviceName, ip) {
+        if (!ip || ip === 'N/A') return;
 
+        const deviceData = { type: 'openDevice', device: deviceName, ip: ip };
+
+        // Check if we have an existing terminal window that's still open
+        if (this.terminalWindow && !this.terminalWindow.closed) {
+            // Send message to existing terminal window to open new tab
+            this.terminalWindow.postMessage(deviceData, window.location.origin);
+            this.terminalWindow.focus();
+        } else {
+            // Open new terminal window with device parameters
+            const terminalUrl = `/terminal?device=${encodeURIComponent(deviceName)}&ip=${encodeURIComponent(ip)}`;
+            this.terminalWindow = window.open(terminalUrl, 'terminal-page');
+        }
+    }
+
+    /**
+     * Show context menu for a node
+     */
+    showContextMenu(evt) {
+        const node = evt.target;
+        const data = node.data();
+
+        // Hide any existing menu
+        this.hideContextMenu();
+        this.hideTooltip();
+
+        // Create context menu
+        const menu = document.createElement('div');
+        menu.id = 'topo-context-menu';
+        menu.className = 'topology-context-menu';
+
+        // Menu items
+        const menuItems = [
+            {
+                label: 'Open Terminal',
+                icon: '⌨',
+                action: () => {
+                    this.openTerminal(data.label, data.ip);
+                    this.hideContextMenu();
+                },
+                disabled: !data.ip || data.ip === 'N/A'
+            },
+            {
+                label: 'Focus on Device',
+                icon: '🎯',
+                action: () => {
+                    this.enterFocusMode(node);
+                    this.hideContextMenu();
+                }
+            },
+            {
+                type: 'separator'
+            },
+            {
+                label: 'Copy IP Address',
+                icon: '📋',
+                action: () => {
+                    if (data.ip && data.ip !== 'N/A') {
+                        navigator.clipboard.writeText(data.ip);
+                    }
+                    this.hideContextMenu();
+                },
+                disabled: !data.ip || data.ip === 'N/A'
+            }
+        ];
+
+        // Build menu HTML
+        menuItems.forEach(item => {
+            if (item.type === 'separator') {
+                const sep = document.createElement('div');
+                sep.className = 'context-menu-separator';
+                menu.appendChild(sep);
+            } else {
+                const menuItem = document.createElement('div');
+                menuItem.className = 'context-menu-item' + (item.disabled ? ' disabled' : '');
+
+                const icon = document.createElement('span');
+                icon.className = 'context-menu-icon';
+                icon.textContent = item.icon;
+
+                const label = document.createElement('span');
+                label.className = 'context-menu-label';
+                label.textContent = item.label;
+
+                menuItem.appendChild(icon);
+                menuItem.appendChild(label);
+
+                if (!item.disabled) {
+                    menuItem.addEventListener('click', (e) => {
+                        e.stopPropagation();
+                        item.action();
+                    });
+                }
+
+                menu.appendChild(menuItem);
+            }
+        });
+
+        // Add header with device name
+        const header = document.createElement('div');
+        header.className = 'context-menu-header';
+        header.textContent = data.label;
+        menu.insertBefore(header, menu.firstChild);
+
+        // Position menu
+        const renderedPos = evt.renderedPosition;
+        const containerRect = this.container.getBoundingClientRect();
+
+        menu.style.position = 'fixed';
+        menu.style.left = (renderedPos.x + containerRect.left) + 'px';
+        menu.style.top = (renderedPos.y + containerRect.top) + 'px';
+
+        document.body.appendChild(menu);
+        this.contextMenu = menu;
+
+        // Adjust position if off-screen
+        this.adjustMenuPosition(menu);
+    }
+
+    /**
+     * Adjust context menu position to keep it on screen
+     */
+    adjustMenuPosition(menu) {
+        const rect = menu.getBoundingClientRect();
+        const viewportWidth = window.innerWidth;
+        const viewportHeight = window.innerHeight;
+
+        if (rect.right > viewportWidth - 10) {
+            menu.style.left = (viewportWidth - rect.width - 10) + 'px';
+        }
+        if (rect.bottom > viewportHeight - 10) {
+            menu.style.top = (viewportHeight - rect.height - 10) + 'px';
+        }
+    }
+
+    /**
+     * Hide context menu
+     */
+    hideContextMenu() {
+        if (this.contextMenu) {
+            this.contextMenu.remove();
+            this.contextMenu = null;
+        }
+        const existing = document.getElementById('topo-context-menu');
+        if (existing) {
+            existing.remove();
+        }
+    }
+
+    /**
+     * Enter focus mode for a node
+     */
+    enterFocusMode(node) {
         // If already focused on this node, exit focus mode
         if (this.focusMode && this.focusedNode === node.id()) {
             this.exitFocusMode();
@@ -288,7 +441,7 @@ export class EventManager {
                 ${portsHtml}
             </div>
             <div class="tooltip-footer">
-                Click to open terminal
+                Right-click for options
             </div>
         `;
 
@@ -399,8 +552,9 @@ export class EventManager {
      * Handle keyboard shortcuts
      */
     handleKeyDown(evt) {
-        // Escape - exit focus mode, clear selection and highlights
+        // Escape - close context menu, exit focus mode, clear selection and highlights
         if (evt.key === 'Escape') {
+            this.hideContextMenu();
             if (this.focusMode) {
                 this.exitFocusMode();
             } else {
@@ -414,6 +568,7 @@ export class EventManager {
         if (evt.key === 'f' && !evt.ctrlKey && !evt.metaKey) {
             const activeElement = document.activeElement;
             if (activeElement.tagName !== 'INPUT' && activeElement.tagName !== 'TEXTAREA') {
+                this.hideContextMenu();
                 this.exitFocusMode();
                 this.cy.fit(50);
             }
@@ -423,6 +578,7 @@ export class EventManager {
         if (evt.key === 'r' && !evt.ctrlKey && !evt.metaKey) {
             const activeElement = document.activeElement;
             if (activeElement.tagName !== 'INPUT' && activeElement.tagName !== 'TEXTAREA') {
+                this.hideContextMenu();
                 this.exitFocusMode();
                 this.cy.reset();
             }
@@ -466,10 +622,12 @@ export class EventManager {
      */
     destroy() {
         this.hideTooltip();
+        this.hideContextMenu();
         this.hideFocusIndicator();
 
-        // Remove global keydown listener to prevent memory leak
+        // Remove global listeners to prevent memory leak
         document.removeEventListener('keydown', this.boundKeyDownHandler);
+        document.removeEventListener('click', this.boundClickHandler);
 
         // Remove all Cytoscape event listeners
         this.cy.removeAllListeners();

--- a/nested-labvm/atd-docker/uilanding/src/html/js/topology/event-handlers.js
+++ b/nested-labvm/atd-docker/uilanding/src/html/js/topology/event-handlers.js
@@ -8,6 +8,8 @@ export class EventManager {
         this.cy = cy;
         this.container = container;
         this.tooltip = null;
+        this.focusMode = false;
+        this.focusedNode = null;
 
         // Store bound handler reference for proper cleanup (prevents memory leak)
         this.boundKeyDownHandler = (evt) => this.handleKeyDown(evt);
@@ -22,7 +24,10 @@ export class EventManager {
         // Node click - open SSH
         this.cy.on('tap', 'node', (evt) => this.handleNodeClick(evt));
 
-        // Node hover - show tooltip
+        // Node right-click - focus mode
+        this.cy.on('cxttap', 'node', (evt) => this.handleNodeRightClick(evt));
+
+        // Node hover - show tooltip (only when not in focus mode)
         this.cy.on('mouseover', 'node', (evt) => this.handleNodeMouseOver(evt));
         this.cy.on('mouseout', 'node', (evt) => this.handleNodeMouseOut(evt));
 
@@ -30,11 +35,17 @@ export class EventManager {
         this.cy.on('mouseover', 'edge', (evt) => this.handleEdgeMouseOver(evt));
         this.cy.on('mouseout', 'edge', (evt) => this.handleEdgeMouseOut(evt));
 
-        // Background click - clear selections
+        // Background click - clear selections and exit focus mode
         this.cy.on('tap', (evt) => {
             if (evt.target === this.cy) {
+                this.exitFocusMode();
                 this.clearHighlights();
             }
+        });
+
+        // Prevent browser context menu on the topology container
+        this.container.addEventListener('contextmenu', (evt) => {
+            evt.preventDefault();
         });
 
         // Keyboard shortcuts (using stored reference for cleanup)
@@ -42,7 +53,7 @@ export class EventManager {
     }
 
     /**
-     * Handle node click - open SSH session
+     * Handle node click - open SSH session in terminal page
      */
     handleNodeClick(evt) {
         const node = evt.target;
@@ -50,9 +61,114 @@ export class EventManager {
         const deviceName = node.data('label');
 
         if (ip && ip !== 'N/A') {
-            // Open SSH in new tab
-            const sshUrl = `/ssh/host/${ip}`;
-            window.open(sshUrl, `ssh-${deviceName}`, 'noopener,noreferrer');
+            // Navigate to terminal page with device parameters
+            const terminalUrl = `/terminal?device=${encodeURIComponent(deviceName)}&ip=${encodeURIComponent(ip)}`;
+            window.open(terminalUrl, 'terminal-page');
+        }
+    }
+
+    /**
+     * Handle node right-click - enter focus mode
+     * Zooms to the node and highlights only its connections
+     */
+    handleNodeRightClick(evt) {
+        const node = evt.target;
+
+        // If already focused on this node, exit focus mode
+        if (this.focusMode && this.focusedNode === node.id()) {
+            this.exitFocusMode();
+            return;
+        }
+
+        // Enter focus mode
+        this.focusMode = true;
+        this.focusedNode = node.id();
+
+        // Clear any existing highlights
+        this.cy.elements().removeClass('highlighted faded hover focused');
+
+        // Get connected elements
+        const connectedEdges = node.connectedEdges();
+        const connectedNodes = connectedEdges.connectedNodes();
+
+        // Apply focus styling
+        node.addClass('focused');
+        connectedEdges.addClass('highlighted');
+        connectedNodes.addClass('highlighted');
+
+        // Fade everything else
+        this.cy.elements()
+            .not(node)
+            .not(connectedEdges)
+            .not(connectedNodes)
+            .addClass('faded');
+
+        // Animate zoom to the focused node
+        this.cy.animate({
+            center: { eles: node },
+            zoom: 1.5
+        }, {
+            duration: 400,
+            easing: 'ease-out-cubic'
+        });
+
+        // Show focus mode indicator
+        this.showFocusIndicator(node.data('label'));
+    }
+
+    /**
+     * Exit focus mode and restore normal view
+     */
+    exitFocusMode() {
+        if (!this.focusMode) return;
+
+        this.focusMode = false;
+        this.focusedNode = null;
+
+        // Clear all focus-related classes
+        this.cy.elements().removeClass('highlighted faded hover focused');
+
+        // Hide focus indicator
+        this.hideFocusIndicator();
+
+        // Fit the graph back to view
+        this.cy.animate({
+            fit: { padding: 50 }
+        }, {
+            duration: 400,
+            easing: 'ease-out-cubic'
+        });
+    }
+
+    /**
+     * Show focus mode indicator
+     */
+    showFocusIndicator(deviceName) {
+        this.hideFocusIndicator();
+
+        const indicator = document.createElement('div');
+        indicator.id = 'focus-indicator';
+        indicator.className = 'focus-mode-indicator';
+        indicator.innerHTML = `
+            <span class="focus-label">Focus: <strong>${deviceName}</strong></span>
+            <button class="focus-exit-btn" title="Exit focus mode (Esc)">×</button>
+        `;
+
+        // Add click handler to exit button
+        indicator.querySelector('.focus-exit-btn').addEventListener('click', () => {
+            this.exitFocusMode();
+        });
+
+        this.container.appendChild(indicator);
+    }
+
+    /**
+     * Hide focus mode indicator
+     */
+    hideFocusIndicator() {
+        const existing = document.getElementById('focus-indicator');
+        if (existing) {
+            existing.remove();
         }
     }
 
@@ -60,6 +176,9 @@ export class EventManager {
      * Handle node mouse over - show tooltip and highlight connections
      */
     handleNodeMouseOver(evt) {
+        // Don't show hover effects in focus mode
+        if (this.focusMode) return;
+
         const node = evt.target;
         node.addClass('hover');
 
@@ -81,6 +200,9 @@ export class EventManager {
      * Handle node mouse out - hide tooltip and clear highlights
      */
     handleNodeMouseOut(evt) {
+        // Don't clear in focus mode
+        if (this.focusMode) return;
+
         const node = evt.target;
         node.removeClass('hover');
         this.hideTooltip();
@@ -166,7 +288,7 @@ export class EventManager {
                 ${portsHtml}
             </div>
             <div class="tooltip-footer">
-                Click to open SSH session
+                Click to open terminal
             </div>
         `;
 
@@ -277,25 +399,31 @@ export class EventManager {
      * Handle keyboard shortcuts
      */
     handleKeyDown(evt) {
-        // Escape - clear selection and highlights
+        // Escape - exit focus mode, clear selection and highlights
         if (evt.key === 'Escape') {
-            this.cy.$(':selected').unselect();
-            this.clearHighlights();
+            if (this.focusMode) {
+                this.exitFocusMode();
+            } else {
+                this.cy.$(':selected').unselect();
+                this.clearHighlights();
+            }
             this.hideTooltip();
         }
 
-        // 'f' - fit graph to view
+        // 'f' - fit graph to view (exits focus mode first)
         if (evt.key === 'f' && !evt.ctrlKey && !evt.metaKey) {
             const activeElement = document.activeElement;
             if (activeElement.tagName !== 'INPUT' && activeElement.tagName !== 'TEXTAREA') {
+                this.exitFocusMode();
                 this.cy.fit(50);
             }
         }
 
-        // 'r' - reset zoom
+        // 'r' - reset zoom (exits focus mode first)
         if (evt.key === 'r' && !evt.ctrlKey && !evt.metaKey) {
             const activeElement = document.activeElement;
             if (activeElement.tagName !== 'INPUT' && activeElement.tagName !== 'TEXTAREA') {
+                this.exitFocusMode();
                 this.cy.reset();
             }
         }
@@ -338,6 +466,7 @@ export class EventManager {
      */
     destroy() {
         this.hideTooltip();
+        this.hideFocusIndicator();
 
         // Remove global keydown listener to prevent memory leak
         document.removeEventListener('keydown', this.boundKeyDownHandler);

--- a/nested-labvm/atd-docker/uilanding/src/html/js/topology/event-handlers.js
+++ b/nested-labvm/atd-docker/uilanding/src/html/js/topology/event-handlers.js
@@ -445,11 +445,10 @@ export class EventManager {
             </div>
         `;
 
-        // Position tooltip
+        // Position tooltip using fixed positioning
         const renderedPos = evt.renderedPosition;
         const containerRect = this.container.getBoundingClientRect();
 
-        tooltip.style.position = 'absolute';
         tooltip.style.left = (renderedPos.x + containerRect.left + 15) + 'px';
         tooltip.style.top = (renderedPos.y + containerRect.top - 10) + 'px';
 
@@ -489,10 +488,10 @@ export class EventManager {
             </div>
         `;
 
+        // Position tooltip using fixed positioning
         const renderedPos = evt.renderedPosition;
         const containerRect = this.container.getBoundingClientRect();
 
-        tooltip.style.position = 'absolute';
         tooltip.style.left = (renderedPos.x + containerRect.left + 15) + 'px';
         tooltip.style.top = (renderedPos.y + containerRect.top - 10) + 'px';
 

--- a/nested-labvm/atd-docker/uilanding/src/html/js/topology/event-handlers.js
+++ b/nested-labvm/atd-docker/uilanding/src/html/js/topology/event-handlers.js
@@ -4,14 +4,18 @@
  */
 
 export class EventManager {
-    constructor(cy, container) {
+    constructor(cy, container, options = {}) {
         this.cy = cy;
         this.container = container;
+        this.options = options;
         this.tooltip = null;
         this.contextMenu = null;
         this.focusMode = false;
         this.focusedNode = null;
         this.terminalWindow = null;  // Reference to terminal window for tab reuse
+
+        // Custom terminal handler (for embedding in terminal page)
+        this.customTerminalHandler = options.onOpenTerminal || null;
 
         // Store bound handler reference for proper cleanup (prevents memory leak)
         this.boundKeyDownHandler = (evt) => this.handleKeyDown(evt);
@@ -70,10 +74,17 @@ export class EventManager {
 
     /**
      * Open SSH session in terminal page
-     * Uses postMessage to communicate with existing terminal window
+     * Uses postMessage to communicate with existing terminal window,
+     * or calls custom handler if provided (for embedding in terminal page)
      */
     openTerminal(deviceName, ip) {
         if (!ip || ip === 'N/A') return;
+
+        // Use custom handler if provided (e.g., when embedded in terminal page)
+        if (this.customTerminalHandler) {
+            this.customTerminalHandler(deviceName, ip);
+            return;
+        }
 
         const deviceData = { type: 'openDevice', device: deviceName, ip: ip };
 

--- a/nested-labvm/atd-docker/uilanding/src/html/js/topology/event-handlers.js
+++ b/nested-labvm/atd-docker/uilanding/src/html/js/topology/event-handlers.js
@@ -16,6 +16,7 @@ export class EventManager {
 
         // Custom terminal handler (for embedding in terminal page)
         this.customTerminalHandler = options.onOpenTerminal || null;
+        console.log('[EventManager] Custom terminal handler:', this.customTerminalHandler ? 'provided' : 'not provided');
 
         // Store bound handler reference for proper cleanup (prevents memory leak)
         this.boundKeyDownHandler = (evt) => this.handleKeyDown(evt);
@@ -82,7 +83,17 @@ export class EventManager {
 
         // Use custom handler if provided (e.g., when embedded in terminal page)
         if (this.customTerminalHandler) {
+            console.log('[EventManager] Using custom terminal handler for', deviceName, ip);
             this.customTerminalHandler(deviceName, ip);
+            return;
+        }
+
+        console.log('[EventManager] Using default terminal handler for', deviceName, ip);
+
+        // Check if we're already on the terminal page - if so, use TerminalManager directly
+        if (window.location.pathname === '/terminal' && typeof TerminalManager !== 'undefined') {
+            console.log('[EventManager] On terminal page, using TerminalManager directly');
+            TerminalManager.openTerminal(deviceName, ip);
             return;
         }
 

--- a/nested-labvm/atd-docker/uilanding/src/html/js/topology/event-handlers.js
+++ b/nested-labvm/atd-docker/uilanding/src/html/js/topology/event-handlers.js
@@ -1,0 +1,348 @@
+/**
+ * Event Handlers for ATL Interactive Topology Diagram
+ * Handles click-to-SSH, hover tooltips, and path highlighting
+ */
+
+export class EventManager {
+    constructor(cy, container) {
+        this.cy = cy;
+        this.container = container;
+        this.tooltip = null;
+
+        // Store bound handler reference for proper cleanup (prevents memory leak)
+        this.boundKeyDownHandler = (evt) => this.handleKeyDown(evt);
+
+        this.registerHandlers();
+    }
+
+    /**
+     * Register all event handlers
+     */
+    registerHandlers() {
+        // Node click - open SSH
+        this.cy.on('tap', 'node', (evt) => this.handleNodeClick(evt));
+
+        // Node hover - show tooltip
+        this.cy.on('mouseover', 'node', (evt) => this.handleNodeMouseOver(evt));
+        this.cy.on('mouseout', 'node', (evt) => this.handleNodeMouseOut(evt));
+
+        // Edge hover - highlight path
+        this.cy.on('mouseover', 'edge', (evt) => this.handleEdgeMouseOver(evt));
+        this.cy.on('mouseout', 'edge', (evt) => this.handleEdgeMouseOut(evt));
+
+        // Background click - clear selections
+        this.cy.on('tap', (evt) => {
+            if (evt.target === this.cy) {
+                this.clearHighlights();
+            }
+        });
+
+        // Keyboard shortcuts (using stored reference for cleanup)
+        document.addEventListener('keydown', this.boundKeyDownHandler);
+    }
+
+    /**
+     * Handle node click - open SSH session
+     */
+    handleNodeClick(evt) {
+        const node = evt.target;
+        const ip = node.data('ip');
+        const deviceName = node.data('label');
+
+        if (ip && ip !== 'N/A') {
+            // Open SSH in new tab
+            const sshUrl = `/ssh/host/${ip}`;
+            window.open(sshUrl, `ssh-${deviceName}`, 'noopener,noreferrer');
+        }
+    }
+
+    /**
+     * Handle node mouse over - show tooltip and highlight connections
+     */
+    handleNodeMouseOver(evt) {
+        const node = evt.target;
+        node.addClass('hover');
+
+        // Highlight connected edges and nodes
+        const connectedEdges = node.connectedEdges();
+        const connectedNodes = connectedEdges.connectedNodes();
+
+        connectedEdges.addClass('highlighted');
+        connectedNodes.addClass('highlighted');
+
+        // Fade non-connected elements
+        this.cy.elements().not(node).not(connectedEdges).not(connectedNodes).addClass('faded');
+
+        // Show tooltip
+        this.showTooltip(evt);
+    }
+
+    /**
+     * Handle node mouse out - hide tooltip and clear highlights
+     */
+    handleNodeMouseOut(evt) {
+        const node = evt.target;
+        node.removeClass('hover');
+        this.hideTooltip();
+        this.clearHighlights();
+    }
+
+    /**
+     * Handle edge mouse over - highlight the edge and connected nodes
+     */
+    handleEdgeMouseOver(evt) {
+        const edge = evt.target;
+        edge.addClass('hover highlighted');
+
+        const connectedNodes = edge.connectedNodes();
+        connectedNodes.addClass('highlighted');
+
+        // Fade other elements
+        this.cy.elements().not(edge).not(connectedNodes).addClass('faded');
+
+        // Show edge tooltip
+        this.showEdgeTooltip(evt);
+    }
+
+    /**
+     * Handle edge mouse out
+     */
+    handleEdgeMouseOut(evt) {
+        const edge = evt.target;
+        edge.removeClass('hover');
+        this.hideTooltip();
+        this.clearHighlights();
+    }
+
+    /**
+     * Show tooltip for a node
+     */
+    showTooltip(evt) {
+        const node = evt.target;
+        const data = node.data();
+
+        // Remove existing tooltip
+        this.hideTooltip();
+
+        // Create tooltip element
+        const tooltip = document.createElement('div');
+        tooltip.id = 'topo-tooltip';
+        tooltip.className = 'topology-tooltip';
+
+        // Build port list
+        let portsHtml = '';
+        if (data.ports && data.ports.length > 0) {
+            const portItems = data.ports.slice(0, 5).map(p =>
+                `<li>${p.port} → ${p.neighbor}:${p.neighbor_port}</li>`
+            ).join('');
+            const moreCount = data.ports.length - 5;
+            portsHtml = `
+                <div class="tooltip-ports">
+                    <strong>Connections:</strong>
+                    <ul>${portItems}</ul>
+                    ${moreCount > 0 ? `<em>+${moreCount} more</em>` : ''}
+                </div>
+            `;
+        }
+
+        tooltip.innerHTML = `
+            <div class="tooltip-header">
+                <strong>${data.label}</strong>
+                <span class="tooltip-type device-type-${data.device_type}">${data.device_type}</span>
+            </div>
+            <div class="tooltip-body">
+                <div class="tooltip-row">
+                    <span class="tooltip-label">IP:</span>
+                    <span class="tooltip-value">${data.ip}</span>
+                </div>
+                <div class="tooltip-row">
+                    <span class="tooltip-label">MAC:</span>
+                    <span class="tooltip-value">${data.sys_mac}</span>
+                </div>
+                <div class="tooltip-row">
+                    <span class="tooltip-label">Status:</span>
+                    <span class="tooltip-value status-${data.status}">${data.status}</span>
+                </div>
+                ${portsHtml}
+            </div>
+            <div class="tooltip-footer">
+                Click to open SSH session
+            </div>
+        `;
+
+        // Position tooltip
+        const renderedPos = evt.renderedPosition;
+        const containerRect = this.container.getBoundingClientRect();
+
+        tooltip.style.position = 'absolute';
+        tooltip.style.left = (renderedPos.x + containerRect.left + 15) + 'px';
+        tooltip.style.top = (renderedPos.y + containerRect.top - 10) + 'px';
+
+        document.body.appendChild(tooltip);
+        this.tooltip = tooltip;
+
+        // Adjust position if off-screen
+        this.adjustTooltipPosition(tooltip);
+    }
+
+    /**
+     * Show tooltip for an edge
+     */
+    showEdgeTooltip(evt) {
+        const edge = evt.target;
+        const data = edge.data();
+
+        this.hideTooltip();
+
+        const tooltip = document.createElement('div');
+        tooltip.id = 'topo-tooltip';
+        tooltip.className = 'topology-tooltip edge-tooltip';
+
+        tooltip.innerHTML = `
+            <div class="tooltip-header">
+                <strong>Link</strong>
+            </div>
+            <div class="tooltip-body">
+                <div class="tooltip-row">
+                    <span class="tooltip-label">From:</span>
+                    <span class="tooltip-value">${data.source}:${data.source_port}</span>
+                </div>
+                <div class="tooltip-row">
+                    <span class="tooltip-label">To:</span>
+                    <span class="tooltip-value">${data.target}:${data.target_port}</span>
+                </div>
+            </div>
+        `;
+
+        const renderedPos = evt.renderedPosition;
+        const containerRect = this.container.getBoundingClientRect();
+
+        tooltip.style.position = 'absolute';
+        tooltip.style.left = (renderedPos.x + containerRect.left + 15) + 'px';
+        tooltip.style.top = (renderedPos.y + containerRect.top - 10) + 'px';
+
+        document.body.appendChild(tooltip);
+        this.tooltip = tooltip;
+
+        this.adjustTooltipPosition(tooltip);
+    }
+
+    /**
+     * Adjust tooltip position to keep it on screen
+     */
+    adjustTooltipPosition(tooltip) {
+        const rect = tooltip.getBoundingClientRect();
+        const viewportWidth = window.innerWidth;
+        const viewportHeight = window.innerHeight;
+
+        // Adjust horizontal position
+        if (rect.right > viewportWidth - 10) {
+            tooltip.style.left = (viewportWidth - rect.width - 20) + 'px';
+        }
+        if (rect.left < 10) {
+            tooltip.style.left = '10px';
+        }
+
+        // Adjust vertical position
+        if (rect.bottom > viewportHeight - 10) {
+            tooltip.style.top = (viewportHeight - rect.height - 20) + 'px';
+        }
+        if (rect.top < 10) {
+            tooltip.style.top = '10px';
+        }
+    }
+
+    /**
+     * Hide the tooltip
+     */
+    hideTooltip() {
+        if (this.tooltip) {
+            this.tooltip.remove();
+            this.tooltip = null;
+        }
+        const existing = document.getElementById('topo-tooltip');
+        if (existing) {
+            existing.remove();
+        }
+    }
+
+    /**
+     * Clear all highlights and fades
+     */
+    clearHighlights() {
+        this.cy.elements().removeClass('highlighted faded hover');
+    }
+
+    /**
+     * Handle keyboard shortcuts
+     */
+    handleKeyDown(evt) {
+        // Escape - clear selection and highlights
+        if (evt.key === 'Escape') {
+            this.cy.$(':selected').unselect();
+            this.clearHighlights();
+            this.hideTooltip();
+        }
+
+        // 'f' - fit graph to view
+        if (evt.key === 'f' && !evt.ctrlKey && !evt.metaKey) {
+            const activeElement = document.activeElement;
+            if (activeElement.tagName !== 'INPUT' && activeElement.tagName !== 'TEXTAREA') {
+                this.cy.fit(50);
+            }
+        }
+
+        // 'r' - reset zoom
+        if (evt.key === 'r' && !evt.ctrlKey && !evt.metaKey) {
+            const activeElement = document.activeElement;
+            if (activeElement.tagName !== 'INPUT' && activeElement.tagName !== 'TEXTAREA') {
+                this.cy.reset();
+            }
+        }
+    }
+
+    /**
+     * Highlight shortest path between two nodes
+     */
+    highlightPath(sourceId, targetId) {
+        this.clearHighlights();
+
+        const source = this.cy.$id(sourceId);
+        const target = this.cy.$id(targetId);
+
+        if (source.empty() || target.empty()) {
+            console.warn('Source or target node not found');
+            return;
+        }
+
+        const dijkstra = this.cy.elements().dijkstra(source, function(edge) {
+            return 1; // Unweighted
+        });
+
+        const path = dijkstra.pathTo(target);
+
+        if (path.empty()) {
+            console.warn('No path found between nodes');
+            return;
+        }
+
+        // Highlight path
+        path.addClass('highlighted');
+
+        // Fade other elements
+        this.cy.elements().not(path).addClass('faded');
+    }
+
+    /**
+     * Destroy event handlers and clean up resources
+     */
+    destroy() {
+        this.hideTooltip();
+
+        // Remove global keydown listener to prevent memory leak
+        document.removeEventListener('keydown', this.boundKeyDownHandler);
+
+        // Remove all Cytoscape event listeners
+        this.cy.removeAllListeners();
+    }
+}

--- a/nested-labvm/atd-docker/uilanding/src/html/js/topology/filter-manager.js
+++ b/nested-labvm/atd-docker/uilanding/src/html/js/topology/filter-manager.js
@@ -178,9 +178,10 @@ export const DEVICE_TYPE_INFO = {
     'pe': { label: 'PE Routers', color: '#4c5cae' },
     'p': { label: 'P Routers', color: '#6b7cc9' },
     'ce': { label: 'CE Routers', color: '#4c5cae' },
+    'customer': { label: 'Customer', color: '#78d82c' },
     'dci': { label: 'DCI', color: '#051431' },
     'isp': { label: 'ISP', color: '#e30909' },
     'internet': { label: 'Internet', color: '#e30909' },
     'oob': { label: 'OOB', color: '#808080' },
-    'other': { label: 'Devices', color: '#666666' }
+    'other': { label: 'Other', color: '#666666' }
 };

--- a/nested-labvm/atd-docker/uilanding/src/html/js/topology/filter-manager.js
+++ b/nested-labvm/atd-docker/uilanding/src/html/js/topology/filter-manager.js
@@ -178,6 +178,8 @@ export const DEVICE_TYPE_INFO = {
     'pe': { label: 'PE Routers', color: '#4c5cae' },
     'p': { label: 'P Routers', color: '#6b7cc9' },
     'ce': { label: 'CE Routers', color: '#4c5cae' },
+    'gw': { label: 'WAN Gateways', color: '#d4a400' },
+    'rr': { label: 'Route Reflectors', color: '#008b8b' },
     'customer': { label: 'Customer', color: '#78d82c' },
     'dci': { label: 'DCI', color: '#051431' },
     'isp': { label: 'ISP', color: '#e30909' },

--- a/nested-labvm/atd-docker/uilanding/src/html/js/topology/filter-manager.js
+++ b/nested-labvm/atd-docker/uilanding/src/html/js/topology/filter-manager.js
@@ -171,15 +171,16 @@ export class FilterManager {
  */
 export const DEVICE_TYPE_INFO = {
     'spine': { label: 'Spines', color: '#4c5cae' },
-    'leaf': { label: 'Leaves', color: '#78d82c' },
-    'borderleaf': { label: 'Borderleaves', color: '#fbb500' },
+    'leaf': { label: 'Leafs', color: '#78d82c' },
+    'borderleaf': { label: 'Borderleafs', color: '#fbb500' },
     'host': { label: 'Hosts', color: '#dae0fe' },
     'core': { label: 'Core', color: '#071c35' },
     'pe': { label: 'PE Routers', color: '#4c5cae' },
     'p': { label: 'P Routers', color: '#6b7cc9' },
+    'ce': { label: 'CE Routers', color: '#4c5cae' },
     'dci': { label: 'DCI', color: '#051431' },
     'isp': { label: 'ISP', color: '#e30909' },
     'internet': { label: 'Internet', color: '#e30909' },
     'oob': { label: 'OOB', color: '#808080' },
-    'other': { label: 'Other', color: '#666666' }
+    'other': { label: 'Devices', color: '#666666' }
 };

--- a/nested-labvm/atd-docker/uilanding/src/html/js/topology/filter-manager.js
+++ b/nested-labvm/atd-docker/uilanding/src/html/js/topology/filter-manager.js
@@ -1,0 +1,185 @@
+/**
+ * Filter Manager for ATL Interactive Topology Diagram
+ * Handles device type filtering and search functionality
+ */
+
+export class FilterManager {
+    constructor(cy, controlsContainer) {
+        this.cy = cy;
+        this.controlsContainer = controlsContainer;
+        this.filters = {};
+        this.searchTerm = '';
+        this.init();
+    }
+
+    /**
+     * Initialize filter manager
+     */
+    init() {
+        // Get all unique device types from the graph
+        const deviceTypes = new Set();
+        this.cy.nodes().forEach(node => {
+            deviceTypes.add(node.data('device_type'));
+        });
+
+        // Initialize all filters as enabled
+        deviceTypes.forEach(type => {
+            this.filters[type] = true;
+        });
+    }
+
+    /**
+     * Set filter state for a device type
+     */
+    setFilter(deviceType, enabled) {
+        this.filters[deviceType] = enabled;
+        this.applyFilters();
+    }
+
+    /**
+     * Toggle filter for a device type
+     */
+    toggleFilter(deviceType) {
+        this.filters[deviceType] = !this.filters[deviceType];
+        this.applyFilters();
+        return this.filters[deviceType];
+    }
+
+    /**
+     * Set search term
+     */
+    setSearch(term) {
+        this.searchTerm = term.toLowerCase().trim();
+        this.applyFilters();
+    }
+
+    /**
+     * Apply all filters and search
+     */
+    applyFilters() {
+        const searchTerm = this.searchTerm;
+        const filters = this.filters;
+
+        this.cy.batch(() => {
+            this.cy.nodes().forEach(node => {
+                const deviceType = node.data('device_type');
+                const label = node.data('label').toLowerCase();
+                const ip = node.data('ip').toLowerCase();
+
+                // Check type filter
+                const typeVisible = filters[deviceType] !== false;
+
+                // Check search filter
+                let searchVisible = true;
+                if (searchTerm) {
+                    searchVisible = label.includes(searchTerm) ||
+                                   ip.includes(searchTerm) ||
+                                   deviceType.includes(searchTerm);
+                }
+
+                // Show/hide node
+                if (typeVisible && searchVisible) {
+                    node.removeClass('filtered-out');
+                    node.style('display', 'element');
+                } else {
+                    node.addClass('filtered-out');
+                    node.style('display', 'none');
+                }
+            });
+
+            // Hide edges connected to hidden nodes
+            this.cy.edges().forEach(edge => {
+                const source = edge.source();
+                const target = edge.target();
+
+                if (source.hasClass('filtered-out') || target.hasClass('filtered-out')) {
+                    edge.style('display', 'none');
+                } else {
+                    edge.style('display', 'element');
+                }
+            });
+        });
+    }
+
+    /**
+     * Reset all filters
+     */
+    resetFilters() {
+        Object.keys(this.filters).forEach(type => {
+            this.filters[type] = true;
+        });
+        this.searchTerm = '';
+        this.applyFilters();
+    }
+
+    /**
+     * Get current filter state
+     */
+    getFilters() {
+        return { ...this.filters };
+    }
+
+    /**
+     * Get device type counts
+     */
+    getDeviceTypeCounts() {
+        const counts = {};
+        this.cy.nodes().forEach(node => {
+            const type = node.data('device_type');
+            counts[type] = (counts[type] || 0) + 1;
+        });
+        return counts;
+    }
+
+    /**
+     * Show only specific device types
+     */
+    showOnly(deviceTypes) {
+        Object.keys(this.filters).forEach(type => {
+            this.filters[type] = deviceTypes.includes(type);
+        });
+        this.applyFilters();
+    }
+
+    /**
+     * Hide specific device types
+     */
+    hide(deviceTypes) {
+        deviceTypes.forEach(type => {
+            this.filters[type] = false;
+        });
+        this.applyFilters();
+    }
+
+    /**
+     * Get visible node count
+     */
+    getVisibleCount() {
+        return this.cy.nodes().filter(node => !node.hasClass('filtered-out')).length;
+    }
+
+    /**
+     * Get total node count
+     */
+    getTotalCount() {
+        return this.cy.nodes().length;
+    }
+}
+
+/**
+ * Device type display info
+ */
+export const DEVICE_TYPE_INFO = {
+    'spine': { label: 'Spines', color: '#4c5cae' },
+    'leaf': { label: 'Leaves', color: '#78d82c' },
+    'borderleaf': { label: 'Borderleaves', color: '#fbb500' },
+    'host': { label: 'Hosts', color: '#dae0fe' },
+    'core': { label: 'Core', color: '#071c35' },
+    'pe': { label: 'PE Routers', color: '#4c5cae' },
+    'p': { label: 'P Routers', color: '#6b7cc9' },
+    'dci': { label: 'DCI', color: '#051431' },
+    'isp': { label: 'ISP', color: '#e30909' },
+    'internet': { label: 'Internet', color: '#e30909' },
+    'oob': { label: 'OOB', color: '#808080' },
+    'other': { label: 'Other', color: '#666666' }
+};

--- a/nested-labvm/atd-docker/uilanding/src/html/js/topology/layout-config.js
+++ b/nested-labvm/atd-docker/uilanding/src/html/js/topology/layout-config.js
@@ -1,7 +1,23 @@
 /**
  * Layout Configuration for ATL Topology Diagram
- * Uses Dagre for hierarchical network layouts
+ * Uses preset layout with server-calculated positions for organized display
  */
+
+/**
+ * Get Preset layout configuration
+ * Uses positions calculated by the server based on device tiers
+ * Best for organized, predictable layouts
+ */
+export function getPresetLayout() {
+    return {
+        name: 'preset',
+        fit: true,
+        padding: 50,
+        animate: true,
+        animationDuration: 500,
+        animationEasing: 'ease-out-cubic'
+    };
+}
 
 /**
  * Get Dagre hierarchical layout configuration
@@ -135,11 +151,13 @@ export function getGridLayout() {
 
 /**
  * Get layout by name
- * @param {string} layoutName - Name of the layout ('dagre', 'cose', 'concentric', 'grid')
+ * @param {string} layoutName - Name of the layout ('preset', 'dagre', 'cose', 'concentric', 'grid')
  * @returns {Object} Layout configuration
  */
 export function getLayout(layoutName) {
     switch (layoutName) {
+        case 'preset':
+            return getPresetLayout();
         case 'dagre':
             return getDagreLayout();
         case 'cose':
@@ -149,7 +167,7 @@ export function getLayout(layoutName) {
         case 'grid':
             return getGridLayout();
         default:
-            return getDagreLayout();
+            return getPresetLayout();  // Default to preset (server-calculated positions)
     }
 }
 
@@ -157,7 +175,8 @@ export function getLayout(layoutName) {
  * Available layout options for UI
  */
 export const LAYOUT_OPTIONS = [
-    { id: 'dagre', name: 'Hierarchical', description: 'Best for spine-leaf topologies' },
+    { id: 'preset', name: 'Organized', description: 'Tiered layout by device type (default)' },
+    { id: 'dagre', name: 'Hierarchical', description: 'Auto-arranged spine-leaf layout' },
     { id: 'cose', name: 'Force-Directed', description: 'Organic clustering layout' },
     { id: 'concentric', name: 'Concentric', description: 'Circles by device importance' },
     { id: 'grid', name: 'Grid', description: 'Simple grid arrangement' }

--- a/nested-labvm/atd-docker/uilanding/src/html/js/topology/layout-config.js
+++ b/nested-labvm/atd-docker/uilanding/src/html/js/topology/layout-config.js
@@ -1,0 +1,164 @@
+/**
+ * Layout Configuration for ATL Topology Diagram
+ * Uses Dagre for hierarchical network layouts
+ */
+
+/**
+ * Get Dagre hierarchical layout configuration
+ * Best for spine-leaf and tiered network topologies
+ */
+export function getDagreLayout() {
+    return {
+        name: 'dagre',
+        rankDir: 'TB',           // Top to bottom
+        align: 'UL',             // Align upper-left
+        ranker: 'network-simplex',
+        rankSep: 80,             // Separation between ranks (vertical spacing)
+        nodeSep: 50,             // Separation between nodes in same rank
+        edgeSep: 20,             // Separation between edges
+        padding: 30,             // Padding around the layout
+        animate: true,
+        animationDuration: 500,
+        animationEasing: 'ease-out-cubic',
+        fit: true,               // Fit to container
+        spacingFactor: 1.2       // Multiply spacing
+    };
+}
+
+/**
+ * Get CoSE (Compound Spring Embedder) layout configuration
+ * Good for general network graphs with clusters
+ */
+export function getCoseLayout() {
+    return {
+        name: 'cose',
+        idealEdgeLength: 100,
+        nodeOverlap: 20,
+        refresh: 20,
+        fit: true,
+        padding: 30,
+        randomize: false,
+        componentSpacing: 100,
+        nodeRepulsion: 400000,
+        edgeElasticity: 100,
+        nestingFactor: 5,
+        gravity: 80,
+        numIter: 1000,
+        initialTemp: 200,
+        coolingFactor: 0.95,
+        minTemp: 1.0,
+        animate: true,
+        animationDuration: 500
+    };
+}
+
+/**
+ * Get Concentric layout configuration
+ * Places nodes in concentric circles based on degree
+ */
+export function getConcentricLayout() {
+    return {
+        name: 'concentric',
+        fit: true,
+        padding: 30,
+        startAngle: 3 / 2 * Math.PI,
+        sweep: undefined,
+        clockwise: true,
+        equidistant: false,
+        minNodeSpacing: 50,
+        boundingBox: undefined,
+        avoidOverlap: true,
+        nodeDimensionsIncludeLabels: true,
+        height: undefined,
+        width: undefined,
+        spacingFactor: 1.5,
+        concentric: function(node) {
+            // Spines/PE at center, then leaves, then hosts
+            const deviceType = node.data('device_type');
+            switch (deviceType) {
+                case 'spine':
+                case 'pe':
+                case 'core':
+                    return 3;
+                case 'leaf':
+                case 'borderleaf':
+                case 'p':
+                    return 2;
+                case 'host':
+                case 'oob':
+                    return 1;
+                default:
+                    return 1;
+            }
+        },
+        levelWidth: function(nodes) {
+            return nodes.maxDegree() / 4;
+        },
+        animate: true,
+        animationDuration: 500
+    };
+}
+
+/**
+ * Get Grid layout configuration
+ * Simple grid arrangement
+ */
+export function getGridLayout() {
+    return {
+        name: 'grid',
+        fit: true,
+        padding: 30,
+        avoidOverlap: true,
+        avoidOverlapPadding: 10,
+        nodeDimensionsIncludeLabels: true,
+        spacingFactor: 1.5,
+        condense: false,
+        rows: undefined,
+        cols: undefined,
+        position: function(node) { return null; },
+        sort: function(a, b) {
+            // Sort by device type then name
+            const typeOrder = {
+                'spine': 0, 'pe': 1, 'core': 2,
+                'leaf': 3, 'borderleaf': 4, 'p': 5,
+                'host': 6, 'oob': 7, 'other': 8
+            };
+            const typeA = typeOrder[a.data('device_type')] || 99;
+            const typeB = typeOrder[b.data('device_type')] || 99;
+            if (typeA !== typeB) return typeA - typeB;
+            return a.data('label').localeCompare(b.data('label'));
+        },
+        animate: true,
+        animationDuration: 500
+    };
+}
+
+/**
+ * Get layout by name
+ * @param {string} layoutName - Name of the layout ('dagre', 'cose', 'concentric', 'grid')
+ * @returns {Object} Layout configuration
+ */
+export function getLayout(layoutName) {
+    switch (layoutName) {
+        case 'dagre':
+            return getDagreLayout();
+        case 'cose':
+            return getCoseLayout();
+        case 'concentric':
+            return getConcentricLayout();
+        case 'grid':
+            return getGridLayout();
+        default:
+            return getDagreLayout();
+    }
+}
+
+/**
+ * Available layout options for UI
+ */
+export const LAYOUT_OPTIONS = [
+    { id: 'dagre', name: 'Hierarchical', description: 'Best for spine-leaf topologies' },
+    { id: 'cose', name: 'Force-Directed', description: 'Organic clustering layout' },
+    { id: 'concentric', name: 'Concentric', description: 'Circles by device importance' },
+    { id: 'grid', name: 'Grid', description: 'Simple grid arrangement' }
+];

--- a/nested-labvm/atd-docker/uilanding/src/html/js/topology/status-updater.js
+++ b/nested-labvm/atd-docker/uilanding/src/html/js/topology/status-updater.js
@@ -1,0 +1,240 @@
+/**
+ * Status Updater for ATL Interactive Topology Diagram
+ * Handles WebSocket integration for real-time device status updates
+ */
+
+export class StatusUpdater {
+    constructor(cy, wsUrl) {
+        this.cy = cy;
+        this.wsUrl = wsUrl;
+        this.ws = null;
+        this.reconnectAttempts = 0;
+        this.maxReconnectAttempts = 5;
+        this.reconnectDelay = 2000;
+        this.statusCallbacks = [];
+    }
+
+    /**
+     * Connect to WebSocket
+     */
+    connect() {
+        if (this.ws && (this.ws.readyState === WebSocket.OPEN || this.ws.readyState === WebSocket.CONNECTING)) {
+            return;
+        }
+
+        try {
+            this.ws = new WebSocket(this.wsUrl);
+
+            this.ws.onopen = () => {
+                console.log('[TopologyStatus] WebSocket connected');
+                this.reconnectAttempts = 0;
+
+                // Send hello message to start receiving updates
+                this.ws.send(JSON.stringify({
+                    type: 'hello',
+                    data: {}
+                }));
+            };
+
+            this.ws.onmessage = (event) => {
+                this.handleMessage(event);
+            };
+
+            this.ws.onclose = (event) => {
+                console.log('[TopologyStatus] WebSocket closed', event.code, event.reason);
+                this.scheduleReconnect();
+            };
+
+            this.ws.onerror = (error) => {
+                console.error('[TopologyStatus] WebSocket error', error);
+            };
+
+        } catch (error) {
+            console.error('[TopologyStatus] Failed to create WebSocket', error);
+            this.scheduleReconnect();
+        }
+    }
+
+    /**
+     * Schedule reconnection attempt
+     */
+    scheduleReconnect() {
+        if (this.reconnectAttempts >= this.maxReconnectAttempts) {
+            console.warn('[TopologyStatus] Max reconnect attempts reached');
+            return;
+        }
+
+        this.reconnectAttempts++;
+        const delay = this.reconnectDelay * Math.pow(2, this.reconnectAttempts - 1);
+
+        console.log(`[TopologyStatus] Reconnecting in ${delay}ms (attempt ${this.reconnectAttempts})`);
+
+        setTimeout(() => {
+            this.connect();
+        }, delay);
+    }
+
+    /**
+     * Handle incoming WebSocket message
+     */
+    handleMessage(event) {
+        try {
+            const msg = JSON.parse(event.data);
+
+            if (msg.type === 'status') {
+                this.processStatusUpdate(msg.data);
+            }
+        } catch (error) {
+            console.error('[TopologyStatus] Error parsing message', error);
+        }
+    }
+
+    /**
+     * Process status update from WebSocket
+     */
+    processStatusUpdate(data) {
+        // Handle CVP status
+        if (data.cvp) {
+            const cvpStatus = data.cvp.status === 'UP' ? 'up' : 'down';
+            // If there's a CVP node, update its status
+            const cvpNode = this.cy.$id('CVP');
+            if (!cvpNode.empty()) {
+                this.updateNodeStatus('CVP', cvpStatus);
+            }
+        }
+
+        // Handle per-device status if available
+        if (data.devices) {
+            Object.entries(data.devices).forEach(([nodeId, status]) => {
+                this.updateNodeStatus(nodeId, status.status || 'unknown');
+            });
+        }
+
+        // Notify callbacks
+        this.statusCallbacks.forEach(callback => {
+            try {
+                callback(data);
+            } catch (error) {
+                console.error('[TopologyStatus] Callback error', error);
+            }
+        });
+    }
+
+    /**
+     * Update a node's status
+     */
+    updateNodeStatus(nodeId, status) {
+        const node = this.cy.$id(nodeId);
+
+        if (node.empty()) {
+            return;
+        }
+
+        // Update node data
+        node.data('status', status);
+
+        // Update CSS classes
+        node.removeClass('status-up status-down status-init status-unknown');
+        node.addClass(`status-${status}`);
+
+        // Update classes string
+        const deviceType = node.data('device_type');
+        node.classes(`device-type-${deviceType} status-${status}`);
+    }
+
+    /**
+     * Simulate device status (for testing/demo)
+     * In production, this would come from CVP or device monitoring
+     */
+    simulateStatus() {
+        const statuses = ['up', 'up', 'up', 'up', 'down', 'init'];
+
+        this.cy.nodes().forEach(node => {
+            const randomStatus = statuses[Math.floor(Math.random() * statuses.length)];
+            this.updateNodeStatus(node.id(), randomStatus);
+        });
+    }
+
+    /**
+     * Set all nodes to a specific status
+     */
+    setAllStatus(status) {
+        this.cy.nodes().forEach(node => {
+            this.updateNodeStatus(node.id(), status);
+        });
+    }
+
+    /**
+     * Register callback for status updates
+     */
+    onStatusUpdate(callback) {
+        this.statusCallbacks.push(callback);
+    }
+
+    /**
+     * Remove status update callback
+     */
+    offStatusUpdate(callback) {
+        const index = this.statusCallbacks.indexOf(callback);
+        if (index > -1) {
+            this.statusCallbacks.splice(index, 1);
+        }
+    }
+
+    /**
+     * Get connection state
+     */
+    isConnected() {
+        return this.ws && this.ws.readyState === WebSocket.OPEN;
+    }
+
+    /**
+     * Get current status for a node
+     */
+    getNodeStatus(nodeId) {
+        const node = this.cy.$id(nodeId);
+        if (node.empty()) {
+            return null;
+        }
+        return node.data('status');
+    }
+
+    /**
+     * Get status summary
+     */
+    getStatusSummary() {
+        const summary = {
+            up: 0,
+            down: 0,
+            init: 0,
+            unknown: 0,
+            total: 0
+        };
+
+        this.cy.nodes().forEach(node => {
+            const status = node.data('status') || 'unknown';
+            summary[status] = (summary[status] || 0) + 1;
+            summary.total++;
+        });
+
+        return summary;
+    }
+
+    /**
+     * Disconnect WebSocket
+     */
+    disconnect() {
+        if (this.ws) {
+            this.ws.close();
+            this.ws = null;
+        }
+    }
+
+    /**
+     * Destroy status updater
+     */
+    destroy() {
+        this.disconnect();
+        this.statusCallbacks = [];
+    }
+}

--- a/nested-labvm/atd-docker/uilanding/src/html/js/topology/topology-manager.js
+++ b/nested-labvm/atd-docker/uilanding/src/html/js/topology/topology-manager.js
@@ -28,6 +28,7 @@ export class TopologyManager {
         this.statusUpdater = null;
         this.isInitialized = false;
         this.topologyData = null;
+        this.originalPositions = {};  // Store original positions for reset
     }
 
     /**
@@ -112,6 +113,16 @@ export class TopologyManager {
             ...this.topologyData.nodes,
             ...this.topologyData.edges
         ];
+
+        // Store original positions for reset functionality
+        this.topologyData.nodes.forEach(node => {
+            if (node.position) {
+                this.originalPositions[node.data.id] = {
+                    x: node.position.x,
+                    y: node.position.y
+                };
+            }
+        });
 
         // Create Cytoscape instance
         this.cy = cytoscape({
@@ -208,8 +219,32 @@ export class TopologyManager {
     setLayout(layoutName) {
         if (!this.cy) return;
 
-        const layout = getLayout(layoutName);
-        this.cy.layout(layout).run();
+        // For preset layout, restore original server-calculated positions with animation
+        if (layoutName === 'preset' && Object.keys(this.originalPositions).length > 0) {
+            this.cy.nodes().forEach(node => {
+                const originalPos = this.originalPositions[node.id()];
+                if (originalPos) {
+                    node.animate({
+                        position: originalPos
+                    }, {
+                        duration: 400,
+                        easing: 'ease-out-cubic'
+                    });
+                }
+            });
+            // Fit after animation completes
+            setTimeout(() => {
+                this.cy.animate({
+                    fit: { padding: 50 }
+                }, {
+                    duration: 200
+                });
+            }, 400);
+        } else {
+            const layout = getLayout(layoutName);
+            this.cy.layout(layout).run();
+        }
+
         this.options.layout = layoutName;
     }
 
@@ -330,10 +365,11 @@ export class TopologyManager {
     }
 
     /**
-     * Clear all highlights
+     * Clear all highlights and exit focus mode
      */
     clearHighlights() {
         if (this.eventManager) {
+            this.eventManager.exitFocusMode();
             this.eventManager.clearHighlights();
         }
     }

--- a/nested-labvm/atd-docker/uilanding/src/html/js/topology/topology-manager.js
+++ b/nested-labvm/atd-docker/uilanding/src/html/js/topology/topology-manager.js
@@ -62,6 +62,7 @@ export class TopologyManager {
             this.initCytoscape();
 
             // Setup components
+            console.log('[TopologyManager] onOpenTerminal option:', this.options.onOpenTerminal ? 'provided' : 'not provided');
             this.eventManager = new EventManager(this.cy, this.container, {
                 onOpenTerminal: this.options.onOpenTerminal
             });

--- a/nested-labvm/atd-docker/uilanding/src/html/js/topology/topology-manager.js
+++ b/nested-labvm/atd-docker/uilanding/src/html/js/topology/topology-manager.js
@@ -62,7 +62,9 @@ export class TopologyManager {
             this.initCytoscape();
 
             // Setup components
-            this.eventManager = new EventManager(this.cy, this.container);
+            this.eventManager = new EventManager(this.cy, this.container, {
+                onOpenTerminal: this.options.onOpenTerminal
+            });
 
             if (this.options.enableFilters) {
                 this.filterManager = new FilterManager(this.cy, this.container);

--- a/nested-labvm/atd-docker/uilanding/src/html/js/topology/topology-manager.js
+++ b/nested-labvm/atd-docker/uilanding/src/html/js/topology/topology-manager.js
@@ -16,7 +16,7 @@ export class TopologyManager {
         this.options = {
             apiUrl: options.apiUrl || '/td-api/topology',
             wsUrl: options.wsUrl || this.getDefaultWsUrl(),
-            layout: options.layout || 'dagre',
+            layout: options.layout || 'preset',  // Default to preset (server-calculated positions)
             enableStatus: options.enableStatus !== false,
             enableFilters: options.enableFilters !== false,
             ...options

--- a/nested-labvm/atd-docker/uilanding/src/html/js/topology/topology-manager.js
+++ b/nested-labvm/atd-docker/uilanding/src/html/js/topology/topology-manager.js
@@ -1,0 +1,410 @@
+/**
+ * Topology Manager for ATL Interactive Topology Diagram
+ * Main orchestrator that brings together all topology components
+ */
+
+import { getCytoscapeStyles } from './cytoscape-styles.js';
+import { getLayout, LAYOUT_OPTIONS } from './layout-config.js';
+import { EventManager } from './event-handlers.js';
+import { FilterManager, DEVICE_TYPE_INFO } from './filter-manager.js';
+import { StatusUpdater } from './status-updater.js';
+
+export class TopologyManager {
+    constructor(containerId, options = {}) {
+        this.containerId = containerId;
+        this.container = document.getElementById(containerId);
+        this.options = {
+            apiUrl: options.apiUrl || '/td-api/topology',
+            wsUrl: options.wsUrl || this.getDefaultWsUrl(),
+            layout: options.layout || 'dagre',
+            enableStatus: options.enableStatus !== false,
+            enableFilters: options.enableFilters !== false,
+            ...options
+        };
+
+        this.cy = null;
+        this.eventManager = null;
+        this.filterManager = null;
+        this.statusUpdater = null;
+        this.isInitialized = false;
+        this.topologyData = null;
+    }
+
+    /**
+     * Get default WebSocket URL based on current location
+     */
+    getDefaultWsUrl() {
+        const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+        return `${protocol}//${window.location.host}/td-ws`;
+    }
+
+    /**
+     * Initialize the topology diagram
+     */
+    async init() {
+        if (this.isInitialized) {
+            console.warn('[TopologyManager] Already initialized');
+            return;
+        }
+
+        try {
+            this.showLoading();
+
+            // Fetch topology data
+            this.topologyData = await this.fetchTopology();
+
+            if (!this.topologyData || !this.topologyData.nodes) {
+                throw new Error('Invalid topology data received');
+            }
+
+            // Initialize Cytoscape
+            this.initCytoscape();
+
+            // Setup components
+            this.eventManager = new EventManager(this.cy, this.container);
+
+            if (this.options.enableFilters) {
+                this.filterManager = new FilterManager(this.cy, this.container);
+            }
+
+            if (this.options.enableStatus) {
+                this.statusUpdater = new StatusUpdater(this.cy, this.options.wsUrl);
+                this.statusUpdater.connect();
+            }
+
+            this.isInitialized = true;
+            this.hideLoading();
+
+            console.log('[TopologyManager] Initialized successfully', {
+                nodes: this.topologyData.nodes.length,
+                edges: this.topologyData.edges.length
+            });
+
+            return this;
+
+        } catch (error) {
+            console.error('[TopologyManager] Initialization failed', error);
+            this.showError(error.message);
+            throw error;
+        }
+    }
+
+    /**
+     * Fetch topology data from API
+     */
+    async fetchTopology() {
+        const response = await fetch(this.options.apiUrl);
+
+        if (!response.ok) {
+            const error = await response.json().catch(() => ({}));
+            throw new Error(error.error || `HTTP ${response.status}`);
+        }
+
+        return await response.json();
+    }
+
+    /**
+     * Initialize Cytoscape instance
+     */
+    initCytoscape() {
+        // Prepare elements
+        const elements = [
+            ...this.topologyData.nodes,
+            ...this.topologyData.edges
+        ];
+
+        // Create Cytoscape instance
+        this.cy = cytoscape({
+            container: this.container,
+            elements: elements,
+            style: getCytoscapeStyles(),
+            layout: getLayout(this.options.layout),
+            minZoom: 0.2,
+            maxZoom: 3,
+            wheelSensitivity: 0.3,
+            boxSelectionEnabled: true,
+            selectionType: 'single'
+        });
+
+        // Run layout
+        this.cy.layout(getLayout(this.options.layout)).run();
+    }
+
+    /**
+     * Show loading indicator
+     */
+    showLoading() {
+        if (!this.container) return;
+
+        const loader = document.createElement('div');
+        loader.id = 'topo-loader';
+        loader.className = 'topology-loader';
+        loader.innerHTML = `
+            <div class="loader-spinner"></div>
+            <div class="loader-text">Loading topology...</div>
+        `;
+        this.container.appendChild(loader);
+    }
+
+    /**
+     * Hide loading indicator
+     */
+    hideLoading() {
+        const loader = document.getElementById('topo-loader');
+        if (loader) {
+            loader.remove();
+        }
+    }
+
+    /**
+     * Show error message
+     * @param {string} message - Error message to display
+     */
+    showError(message) {
+        this.hideLoading();
+
+        if (!this.container) return;
+
+        // Create error container
+        const error = document.createElement('div');
+        error.id = 'topo-error';
+        error.className = 'topology-error';
+        error.setAttribute('role', 'alert');
+        error.setAttribute('aria-live', 'assertive');
+
+        // Create error icon
+        const errorIcon = document.createElement('div');
+        errorIcon.className = 'error-icon';
+        errorIcon.textContent = '!';
+
+        // Create error title
+        const errorTitle = document.createElement('div');
+        errorTitle.className = 'error-title';
+        errorTitle.textContent = 'Failed to load topology';
+
+        // Create error message (escaped to prevent XSS)
+        const errorMessage = document.createElement('div');
+        errorMessage.className = 'error-message';
+        errorMessage.textContent = message;
+
+        // Create retry button with proper event listener (no inline onclick)
+        const retryBtn = document.createElement('button');
+        retryBtn.className = 'error-retry';
+        retryBtn.textContent = 'Retry';
+        retryBtn.addEventListener('click', () => location.reload());
+
+        // Assemble error element
+        error.appendChild(errorIcon);
+        error.appendChild(errorTitle);
+        error.appendChild(errorMessage);
+        error.appendChild(retryBtn);
+
+        this.container.appendChild(error);
+    }
+
+    /**
+     * Change layout algorithm
+     */
+    setLayout(layoutName) {
+        if (!this.cy) return;
+
+        const layout = getLayout(layoutName);
+        this.cy.layout(layout).run();
+        this.options.layout = layoutName;
+    }
+
+    /**
+     * Fit graph to container
+     */
+    fit(padding = 50) {
+        if (this.cy) {
+            this.cy.fit(padding);
+        }
+    }
+
+    /**
+     * Reset zoom and pan
+     */
+    reset() {
+        if (this.cy) {
+            this.cy.reset();
+        }
+    }
+
+    /**
+     * Center on a specific node
+     */
+    centerOnNode(nodeId, zoom = 1.5) {
+        if (!this.cy) return;
+
+        const node = this.cy.$id(nodeId);
+        if (!node.empty()) {
+            this.cy.animate({
+                center: { eles: node },
+                zoom: zoom,
+                duration: 500
+            });
+        }
+    }
+
+    /**
+     * Get node by ID
+     */
+    getNode(nodeId) {
+        if (!this.cy) return null;
+        const node = this.cy.$id(nodeId);
+        return node.empty() ? null : node;
+    }
+
+    /**
+     * Get all nodes
+     */
+    getNodes() {
+        if (!this.cy) return [];
+        return this.cy.nodes().toArray();
+    }
+
+    /**
+     * Get all edges
+     */
+    getEdges() {
+        if (!this.cy) return [];
+        return this.cy.edges().toArray();
+    }
+
+    /**
+     * Search for nodes by name or IP
+     */
+    search(term) {
+        if (this.filterManager) {
+            this.filterManager.setSearch(term);
+        }
+    }
+
+    /**
+     * Toggle device type visibility
+     */
+    toggleDeviceType(deviceType) {
+        if (this.filterManager) {
+            return this.filterManager.toggleFilter(deviceType);
+        }
+        return true;
+    }
+
+    /**
+     * Get filter state
+     */
+    getFilters() {
+        if (this.filterManager) {
+            return this.filterManager.getFilters();
+        }
+        return {};
+    }
+
+    /**
+     * Reset all filters
+     */
+    resetFilters() {
+        if (this.filterManager) {
+            this.filterManager.resetFilters();
+        }
+    }
+
+    /**
+     * Get device type counts
+     */
+    getDeviceTypeCounts() {
+        if (this.filterManager) {
+            return this.filterManager.getDeviceTypeCounts();
+        }
+        return {};
+    }
+
+    /**
+     * Highlight path between two nodes
+     */
+    highlightPath(sourceId, targetId) {
+        if (this.eventManager) {
+            this.eventManager.highlightPath(sourceId, targetId);
+        }
+    }
+
+    /**
+     * Clear all highlights
+     */
+    clearHighlights() {
+        if (this.eventManager) {
+            this.eventManager.clearHighlights();
+        }
+    }
+
+    /**
+     * Get status summary
+     */
+    getStatusSummary() {
+        if (this.statusUpdater) {
+            return this.statusUpdater.getStatusSummary();
+        }
+        return { up: 0, down: 0, init: 0, unknown: 0, total: 0 };
+    }
+
+    /**
+     * Export graph as PNG
+     */
+    exportPNG() {
+        if (!this.cy) return null;
+
+        return this.cy.png({
+            output: 'blob',
+            bg: '#ffffff',
+            full: true,
+            scale: 2
+        });
+    }
+
+    /**
+     * Export graph as JSON
+     */
+    exportJSON() {
+        if (!this.cy) return null;
+
+        return this.cy.json();
+    }
+
+    /**
+     * Get topology metadata
+     */
+    getMetadata() {
+        if (this.topologyData) {
+            return this.topologyData.metadata;
+        }
+        return null;
+    }
+
+    /**
+     * Destroy the topology manager
+     */
+    destroy() {
+        if (this.eventManager) {
+            this.eventManager.destroy();
+        }
+
+        if (this.statusUpdater) {
+            this.statusUpdater.destroy();
+        }
+
+        if (this.cy) {
+            this.cy.destroy();
+        }
+
+        this.container.innerHTML = '';
+        this.isInitialized = false;
+    }
+}
+
+// Export for non-module usage
+if (typeof window !== 'undefined') {
+    window.TopologyManager = TopologyManager;
+    window.LAYOUT_OPTIONS = LAYOUT_OPTIONS;
+    window.DEVICE_TYPE_INFO = DEVICE_TYPE_INFO;
+}

--- a/nested-labvm/atd-docker/uilanding/src/html/terminal.html
+++ b/nested-labvm/atd-docker/uilanding/src/html/terminal.html
@@ -1345,6 +1345,20 @@
     // Initialize
     document.addEventListener('DOMContentLoaded', () => {
       TerminalManager.init();
+
+      // Handle URL parameters from topology diagram clicks
+      const urlParams = new URLSearchParams(window.location.search);
+      const deviceName = urlParams.get('device');
+      const deviceIp = urlParams.get('ip');
+
+      if (deviceName && deviceIp) {
+        // Open the device terminal after a short delay to ensure devices are loaded
+        setTimeout(() => {
+          TerminalManager.openTerminal(deviceName, deviceIp);
+          // Clear URL params to prevent reopening on refresh
+          window.history.replaceState({}, '', '/terminal');
+        }, 500);
+      }
     });
   </script>
 </body>

--- a/nested-labvm/atd-docker/uilanding/src/html/terminal.html
+++ b/nested-labvm/atd-docker/uilanding/src/html/terminal.html
@@ -791,6 +791,28 @@
       color: var(--primary-color);
     }
 
+    /* Tooltip overrides for terminal page - ensure visibility */
+    .topology-tooltip {
+      z-index: 100000 !important;
+    }
+
+    .topology-tooltip .tooltip-value {
+      color: #071c35 !important;
+    }
+
+    .topology-tooltip .tooltip-value.status-unknown {
+      color: #666666 !important;
+    }
+
+    .topology-tooltip .tooltip-footer {
+      color: #666666 !important;
+    }
+
+    /* Context menu z-index for terminal page */
+    .topology-context-menu {
+      z-index: 100001 !important;
+    }
+
     /* Lab guides panel */
     .labguides-panel .side-panel-content {
       padding: 0;
@@ -1433,18 +1455,24 @@
           // Dynamically import the TopologyManager module
           const { TopologyManager } = await import('./js/topology/topology-manager.js');
 
+          // Clear the loading text before initializing
+          const topoContainer = document.getElementById('terminal-topology');
+          topoContainer.textContent = '';
+          topoContainer.classList.remove('loading');
+
           this.topoManager = new TopologyManager('terminal-topology', {
             apiUrl: '/td-api/topology',
             layout: 'preset',
             enableStatus: true,
-            enableFilters: false  // Using our own compact controls
+            enableFilters: false,  // Using our own compact controls
+            // Custom terminal handler for opening devices in this page's tabs
+            onOpenTerminal: (deviceName, ip) => {
+              this.openTerminal(deviceName, ip);
+            }
           });
 
           await this.topoManager.init();
           this.topoInitialized = true;
-
-          // Remove loading state
-          document.getElementById('terminal-topology').classList.remove('loading');
 
           // Setup compact controls
           this.setupTopoControls();

--- a/nested-labvm/atd-docker/uilanding/src/html/terminal.html
+++ b/nested-labvm/atd-docker/uilanding/src/html/terminal.html
@@ -1467,7 +1467,7 @@
             enableFilters: false,  // Using our own compact controls
             // Custom terminal handler for opening devices in this page's tabs
             onOpenTerminal: (deviceName, ip) => {
-              this.openTerminal(deviceName, ip);
+              TerminalManager.openTerminal(deviceName, ip);
             }
           });
 

--- a/nested-labvm/atd-docker/uilanding/src/html/terminal.html
+++ b/nested-labvm/atd-docker/uilanding/src/html/terminal.html
@@ -7,6 +7,7 @@
   <title>Terminal - {{ topo_title }}</title>
   <link rel="stylesheet" href="css/variables.css" />
   <link rel="stylesheet" href="css/typography.css" />
+  <link rel="stylesheet" href="css/topology.css" />
   <style>
     * {
       margin: 0;
@@ -714,13 +715,80 @@
 
     /* Topology panel */
     .topology-panel .side-panel-content {
-      padding: 16px;
+      padding: 0;
+      flex-direction: column;
+      align-items: stretch;
     }
 
     .topology-panel .side-panel-content img {
       max-width: 100%;
       max-height: 100%;
       object-fit: contain;
+    }
+
+    /* Compact topology controls for side panel */
+    .topology-panel .topo-controls {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 6px;
+      padding: 10px 12px;
+      background: var(--primary-color);
+      border-bottom: 1px solid rgba(251, 181, 0, 0.3);
+    }
+
+    .topology-panel .topo-controls input[type="text"] {
+      flex: 1;
+      min-width: 100px;
+      padding: 6px 10px;
+      border: 1px solid rgba(251, 181, 0, 0.5);
+      border-radius: 0;
+      background: var(--navy-blue);
+      color: #fff;
+      font-size: 12px;
+      font-family: inherit;
+    }
+
+    .topology-panel .topo-controls input[type="text"]::placeholder {
+      color: rgba(255, 255, 255, 0.5);
+    }
+
+    .topology-panel .topo-controls input[type="text"]:focus {
+      border-color: var(--secondary-color);
+      outline: none;
+    }
+
+    .topology-panel .topo-controls .topo-btn {
+      padding: 6px 10px;
+      background: transparent;
+      border: 1px solid rgba(251, 181, 0, 0.5);
+      color: var(--secondary-color);
+      font-size: 11px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.3px;
+      cursor: pointer;
+      white-space: nowrap;
+    }
+
+    .topology-panel .topo-controls .topo-btn:hover {
+      background: rgba(251, 181, 0, 0.15);
+      border-color: var(--secondary-color);
+    }
+
+    /* Interactive topology container in side panel */
+    .topology-panel #terminal-topology {
+      flex: 1;
+      min-height: 300px;
+      background: #ffffff;
+      border: 2px solid var(--secondary-color);
+      margin: 12px;
+    }
+
+    .topology-panel #terminal-topology.loading {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      color: var(--primary-color);
     }
 
     /* Lab guides panel */
@@ -786,6 +854,10 @@
 </head>
 
 <body>
+  <!-- Cytoscape.js for Interactive Topology -->
+  <script src="https://unpkg.com/cytoscape@3.28.1/dist/cytoscape.min.js"></script>
+  <script src="https://unpkg.com/dagre@0.8.5/dist/dagre.min.js"></script>
+  <script src="https://unpkg.com/cytoscape-dagre@2.5.0/cytoscape-dagre.js"></script>
   <div class="terminal-container">
     <!-- Device Sidebar -->
     <aside class="device-sidebar" id="deviceSidebar">
@@ -887,7 +959,12 @@
             <button class="side-panel-close" id="topoClose">&times;</button>
           </div>
           <div class="side-panel-content">
-            <img src="/topo/atd-topo.png" alt="Topology Diagram" />
+            <div class="topo-controls">
+              <input type="text" id="topo-search" placeholder="Search..." />
+              <button class="topo-btn" id="topo-reset">Reset</button>
+              <button class="topo-btn" id="topo-fit">Fit</button>
+            </div>
+            <div id="terminal-topology" class="loading">Loading topology...</div>
           </div>
         </div>
       </div>
@@ -1129,6 +1206,10 @@
           if (isVisible) {
             labguidesPanel.classList.remove('visible');
             labguidesToggle.classList.remove('active');
+            // Fit topology to panel after it becomes visible
+            if (this.topoManager) {
+              setTimeout(() => this.topoManager.fit(), 100);
+            }
           }
         });
 
@@ -1339,12 +1420,88 @@
 
         // Focus the iframe
         setTimeout(() => iframe.focus(), 50);
+      },
+
+      // Topology Manager for side panel
+      topoManager: null,
+      topoInitialized: false,
+
+      async initTopology() {
+        if (this.topoInitialized) return;
+
+        try {
+          // Dynamically import the TopologyManager module
+          const { TopologyManager } = await import('./js/topology/topology-manager.js');
+
+          this.topoManager = new TopologyManager('terminal-topology', {
+            apiUrl: '/td-api/topology',
+            layout: 'preset',
+            enableStatus: true,
+            enableFilters: false  // Using our own compact controls
+          });
+
+          await this.topoManager.init();
+          this.topoInitialized = true;
+
+          // Remove loading state
+          document.getElementById('terminal-topology').classList.remove('loading');
+
+          // Setup compact controls
+          this.setupTopoControls();
+
+        } catch (error) {
+          console.error('Failed to initialize topology:', error);
+          document.getElementById('terminal-topology').innerHTML =
+            '<div style="padding: 20px; text-align: center; color: #e74c3c;">Failed to load topology</div>';
+        }
+      },
+
+      setupTopoControls() {
+        // Search input
+        const searchInput = document.getElementById('topo-search');
+        if (searchInput) {
+          let searchTimeout;
+          searchInput.addEventListener('input', () => {
+            clearTimeout(searchTimeout);
+            searchTimeout = setTimeout(() => {
+              if (this.topoManager) {
+                this.topoManager.search(searchInput.value);
+              }
+            }, 300);
+          });
+        }
+
+        // Reset button
+        const resetBtn = document.getElementById('topo-reset');
+        if (resetBtn) {
+          resetBtn.addEventListener('click', () => {
+            if (this.topoManager) {
+              this.topoManager.clearHighlights();
+              this.topoManager.setLayout('preset');
+              this.topoManager.resetFilters();
+              document.getElementById('topo-search').value = '';
+            }
+          });
+        }
+
+        // Fit button
+        const fitBtn = document.getElementById('topo-fit');
+        if (fitBtn) {
+          fitBtn.addEventListener('click', () => {
+            if (this.topoManager) {
+              this.topoManager.fit();
+            }
+          });
+        }
       }
     };
 
     // Initialize
-    document.addEventListener('DOMContentLoaded', () => {
+    document.addEventListener('DOMContentLoaded', async () => {
       TerminalManager.init();
+
+      // Initialize topology when panel is opened
+      await TerminalManager.initTopology();
 
       // Handle URL parameters from topology diagram clicks (first open)
       const urlParams = new URLSearchParams(window.location.search);

--- a/nested-labvm/atd-docker/uilanding/src/html/terminal.html
+++ b/nested-labvm/atd-docker/uilanding/src/html/terminal.html
@@ -1346,7 +1346,7 @@
     document.addEventListener('DOMContentLoaded', () => {
       TerminalManager.init();
 
-      // Handle URL parameters from topology diagram clicks
+      // Handle URL parameters from topology diagram clicks (first open)
       const urlParams = new URLSearchParams(window.location.search);
       const deviceName = urlParams.get('device');
       const deviceIp = urlParams.get('ip');
@@ -1359,6 +1359,17 @@
           window.history.replaceState({}, '', '/terminal');
         }, 500);
       }
+
+      // Listen for messages from topology diagram (subsequent opens)
+      window.addEventListener('message', (event) => {
+        // Verify origin for security
+        if (event.origin !== window.location.origin) return;
+
+        const data = event.data;
+        if (data && data.type === 'openDevice' && data.device && data.ip) {
+          TerminalManager.openTerminal(data.device, data.ip);
+        }
+      });
     });
   </script>
 </body>

--- a/nested-labvm/atd-docker/uilanding/src/uilanding.py
+++ b/nested-labvm/atd-docker/uilanding/src/uilanding.py
@@ -914,9 +914,9 @@ class TopologyAPIHandler(BaseHandler):
 
     # Device type to tier mapping (lower tier = higher in diagram)
     # Tier 0: Internet (top, cloud/WAN edge)
-    # Tier 1: ISP cores (grouped by provider: ISP1, ISP2, etc.)
+    # Tier 1: ISP cores (grouped by provider: ISP1, ISP2, etc.), Route Reflectors
     # Tier 2: DCI, core, P routers (inter-DC connectivity)
-    # Tier 3: Borderleaf, PE, CE (DC edge)
+    # Tier 3: Borderleaf, PE, CE, GW (DC edge / WAN gateways)
     # Tier 4: Spines
     # Tier 5: Leafs
     # Tier 6: Hosts, customers, OOB
@@ -924,12 +924,14 @@ class TopologyAPIHandler(BaseHandler):
     DEVICE_TIERS = {
         'internet': 0,
         'isp': 1,
+        'rr': 1,
         'core': 2,
         'dci': 2,
         'p': 2,
         'borderleaf': 3,
         'pe': 3,
         'ce': 3,
+        'gw': 3,
         'spine': 4,
         'leaf': 5,
         'host': 6,
@@ -962,6 +964,12 @@ class TopologyAPIHandler(BaseHandler):
             return 'core'
         elif 'oob' in name_lower:
             return 'oob'
+        # Route Reflector: RR or RR1, RR2, etc.
+        elif device_name == 'RR' or (device_name.startswith('RR') and len(device_name) > 2 and device_name[2].isdigit()):
+            return 'rr'
+        # WAN Gateways: GW11, GW12, GW21, GW22, GW31, etc. (GW + DC number + device number)
+        elif device_name.startswith('GW') and len(device_name) > 2 and device_name[2].isdigit():
+            return 'gw'
         elif device_name.startswith('PE'):
             return 'pe'
         elif device_name.startswith('CE'):
@@ -979,12 +987,20 @@ class TopologyAPIHandler(BaseHandler):
         """
         Extract datacenter identifier from device name.
         E.g., 'spine1-DC1' -> 'DC1', 'leaf2-DC2' -> 'DC2', 'host1' -> ''
+        Also handles WAN Gateway naming: 'GW11' -> 'DC1', 'GW21' -> 'DC2', 'GW31' -> 'DC3'
         """
         import re
         # Match -DC followed by number or letter at end of name
         match = re.search(r'-?(DC\d+|dc\d+)$', device_name, re.IGNORECASE)
         if match:
             return match.group(1).upper()
+
+        # Handle GW device naming: GW11, GW12 -> DC1, GW21, GW22 -> DC2, GW31 -> DC3
+        # First digit after GW is the DC number
+        if device_name.startswith('GW') and len(device_name) >= 3 and device_name[2].isdigit():
+            dc_num = device_name[2]
+            return f'DC{dc_num}'
+
         return ''  # No datacenter suffix
 
     @staticmethod
@@ -1519,6 +1535,8 @@ class DevicesAPIHandler(BaseHandler):
                 ('Host', ['Host']),
                 ('Core', ['Core', 'DCI']),
                 ('ISP', ['ISP', 'Internet']),
+                ('Route Reflectors', ['RR']),
+                ('WAN Gateways', ['GW']),
                 ('PE Routers', ['PE']),
                 ('P Routers', ['P']),
                 ('Customer', []),  # Special handling for A, B, C, D prefixed devices

--- a/nested-labvm/atd-docker/uilanding/src/uilanding.py
+++ b/nested-labvm/atd-docker/uilanding/src/uilanding.py
@@ -1026,7 +1026,7 @@ class TopologyAPIHandler(BaseHandler):
 
         # Calculate positions
         NODE_SPACING_X = 150   # Horizontal spacing between nodes
-        NODE_SPACING_Y = 120   # Vertical spacing between tiers
+        NODE_SPACING_Y = 180   # Vertical spacing between tiers
         DC_SPACING = 80        # Extra spacing between datacenter groups
         PADDING = 100          # Left padding
 

--- a/nested-labvm/atd-docker/uilanding/src/uilanding.py
+++ b/nested-labvm/atd-docker/uilanding/src/uilanding.py
@@ -959,12 +959,6 @@ class TopologyAPIHandler(BaseHandler):
             return 'ce'
         elif device_name.startswith('P') and len(device_name) > 1 and device_name[1].isdigit():
             return 'p'
-        elif device_name.startswith('A') and len(device_name) > 1 and device_name[1].isdigit():
-            return 'leaf'
-        elif device_name.startswith('B') and len(device_name) > 1 and device_name[1].isdigit():
-            return 'leaf'
-        elif device_name.startswith('C') and len(device_name) > 1 and device_name[1].isdigit():
-            return 'leaf'
         else:
             return 'other'
 
@@ -999,13 +993,196 @@ class TopologyAPIHandler(BaseHandler):
         return result
 
     @staticmethod
-    def calculate_positions(nodes_data):
+    def detect_topology_type(nodes_data):
         """
-        Calculate x,y positions for nodes based on tier, datacenter, and sorted order.
-        Organizes nodes in rows by device type, grouped by datacenter with spacing.
+        Detect the type of topology based on device types present.
+        Returns: 'wan' for P-router mesh topologies, 'datacenter' for spine-leaf
+        """
+        device_types = set(node['data']['device_type'] for node in nodes_data)
+
+        has_p_routers = 'p' in device_types
+        has_pe_routers = 'pe' in device_types
+        has_spines = 'spine' in device_types
+        has_leaves = 'leaf' in device_types
+
+        # WAN topology: has P and PE routers, no spines
+        if has_p_routers and has_pe_routers and not has_spines:
+            return 'wan'
+
+        # Datacenter topology: has spines or leaves
+        if has_spines or has_leaves:
+            return 'datacenter'
+
+        # Default to datacenter layout
+        return 'datacenter'
+
+    @staticmethod
+    def extract_site_number(device_name):
+        """
+        Extract site number from device name for WAN topology positioning.
+        E.g., 'PE1' -> 1, 'A2' -> 2, 'PE-1' -> 1, 'SiteA-1' -> 1
+        Returns 1 for "left" side, 2 for "right" side, 0 for center (P routers)
         """
         import re
 
+        # Look for trailing number
+        match = re.search(r'[-_]?(\d+)$', device_name)
+        if match:
+            num = int(match.group(1))
+            # Odd numbers = site 1 (left), Even numbers = site 2 (right)
+            return 1 if num % 2 == 1 else 2
+
+        return 0  # No number found - treat as center
+
+    @staticmethod
+    def calculate_wan_positions(nodes_data, edges_data):
+        """
+        Calculate positions for WAN topology with P-router mesh in center.
+        Layout: Left customers -> Left PEs -> P mesh -> Right PEs -> Right customers
+        """
+        import re
+
+        NODE_SPACING_X = 180   # Horizontal spacing
+        NODE_SPACING_Y = 120   # Vertical spacing
+        COLUMN_SPACING = 200   # Extra spacing between columns
+        PADDING = 100
+
+        # Build adjacency for graph analysis
+        adjacency = {}
+        for node in nodes_data:
+            adjacency[node['data']['id']] = set()
+        for edge in edges_data:
+            src = edge['data']['source']
+            tgt = edge['data']['target']
+            if src in adjacency and tgt in adjacency:
+                adjacency[src].add(tgt)
+                adjacency[tgt].add(src)
+
+        # Categorize nodes
+        p_routers = []
+        pe_routers = []
+        customer_devices = []  # CE, hosts, or other edge devices
+        other_devices = []
+
+        for node in nodes_data:
+            dtype = node['data']['device_type']
+            if dtype == 'p':
+                p_routers.append(node)
+            elif dtype == 'pe':
+                pe_routers.append(node)
+            elif dtype in ('ce', 'host', 'leaf', 'other'):
+                customer_devices.append(node)
+            else:
+                other_devices.append(node)
+
+        # Determine which side each PE is on using graph analysis
+        # PEs are on "left" if their connected customers have odd site numbers
+        pe_sides = {}
+        for pe in pe_routers:
+            pe_id = pe['data']['id']
+            pe_neighbors = adjacency.get(pe_id, set())
+
+            # Check connected devices (excluding P routers)
+            side_votes = []
+            for neighbor in pe_neighbors:
+                neighbor_node = next((n for n in nodes_data if n['data']['id'] == neighbor), None)
+                if neighbor_node and neighbor_node['data']['device_type'] != 'p':
+                    site = TopologyAPIHandler.extract_site_number(neighbor)
+                    if site > 0:
+                        side_votes.append(site)
+
+            # Also consider the PE's own name
+            pe_site = TopologyAPIHandler.extract_site_number(pe_id)
+            if pe_site > 0:
+                side_votes.append(pe_site)
+
+            # Majority vote, default to name-based
+            if side_votes:
+                pe_sides[pe_id] = 1 if side_votes.count(1) >= side_votes.count(2) else 2
+            else:
+                pe_sides[pe_id] = pe_site if pe_site > 0 else 1
+
+        # Determine customer sides based on their PE connections
+        customer_sides = {}
+        for cust in customer_devices:
+            cust_id = cust['data']['id']
+            cust_neighbors = adjacency.get(cust_id, set())
+
+            # Find connected PEs
+            for neighbor in cust_neighbors:
+                if neighbor in pe_sides:
+                    customer_sides[cust_id] = pe_sides[neighbor]
+                    break
+
+            # Fallback to name-based
+            if cust_id not in customer_sides:
+                site = TopologyAPIHandler.extract_site_number(cust_id)
+                customer_sides[cust_id] = site if site > 0 else 1
+
+        # Split into columns (left to right)
+        left_customers = [n for n in customer_devices if customer_sides.get(n['data']['id'], 1) == 1]
+        left_pes = [n for n in pe_routers if pe_sides.get(n['data']['id'], 1) == 1]
+        right_pes = [n for n in pe_routers if pe_sides.get(n['data']['id'], 2) == 2]
+        right_customers = [n for n in customer_devices if customer_sides.get(n['data']['id'], 1) == 2]
+
+        # Sort each group by name
+        for group in [left_customers, left_pes, p_routers, right_pes, right_customers]:
+            group.sort(key=lambda n: TopologyAPIHandler.get_sort_key(n['data']['id']))
+
+        # Calculate column X positions
+        columns = [left_customers, left_pes, p_routers, right_pes, right_customers]
+        column_names = ['left_cust', 'left_pe', 'p_mesh', 'right_pe', 'right_cust']
+
+        # Find max height (most nodes in any column)
+        max_height = max(len(col) for col in columns) if columns else 1
+
+        # Position each column
+        current_x = PADDING
+        for col_idx, column in enumerate(columns):
+            if not column:
+                continue
+
+            # Center column vertically
+            col_height = len(column) * NODE_SPACING_Y
+            start_y = PADDING + (max_height * NODE_SPACING_Y - col_height) / 2
+
+            for row_idx, node in enumerate(column):
+                node['position'] = {
+                    'x': current_x,
+                    'y': start_y + row_idx * NODE_SPACING_Y
+                }
+                node['data']['wan_column'] = column_names[col_idx]
+
+            current_x += COLUMN_SPACING
+
+        # Position any other devices at the top
+        if other_devices:
+            other_devices.sort(key=lambda n: TopologyAPIHandler.get_sort_key(n['data']['id']))
+            for idx, node in enumerate(other_devices):
+                node['position'] = {
+                    'x': PADDING + idx * NODE_SPACING_X,
+                    'y': PADDING / 2
+                }
+                node['data']['wan_column'] = 'other'
+
+        return nodes_data
+
+    @staticmethod
+    def calculate_positions(nodes_data, edges_data=None):
+        """
+        Calculate x,y positions for nodes based on topology type.
+        Automatically detects WAN vs datacenter topologies.
+        """
+        import re
+
+        # Detect topology type
+        topo_type = TopologyAPIHandler.detect_topology_type(nodes_data)
+
+        # Use WAN layout for P-router mesh topologies
+        if topo_type == 'wan' and edges_data:
+            return TopologyAPIHandler.calculate_wan_positions(nodes_data, edges_data)
+
+        # Standard datacenter layout (tier-based)
         # Group nodes by tier, then by datacenter
         tiers = {}
         for node in nodes_data:
@@ -1205,7 +1382,8 @@ class TopologyAPIHandler(BaseHandler):
                 })
 
         # Calculate positions based on device type tiers and natural name sorting
-        nodes = self.calculate_positions(nodes)
+        # Pass edges for WAN topology detection which uses graph adjacency
+        nodes = self.calculate_positions(nodes, edges)
 
         return {
             'data': {

--- a/nested-labvm/atd-docker/uilanding/src/uilanding.py
+++ b/nested-labvm/atd-docker/uilanding/src/uilanding.py
@@ -918,13 +918,14 @@ class TopologyAPIHandler(BaseHandler):
         'isp': 0,
         'core': 1,
         'dci': 1,
-        'spine': 2,
+        'p': 1,
+        'borderleaf': 2,
         'pe': 2,
-        'p': 3,
-        'borderleaf': 3,
+        'ce': 2,
+        'spine': 3,
         'leaf': 4,
-        'oob': 5,
         'host': 5,
+        'oob': 5,
         'other': 6
     }
 
@@ -954,6 +955,8 @@ class TopologyAPIHandler(BaseHandler):
             return 'oob'
         elif device_name.startswith('PE'):
             return 'pe'
+        elif device_name.startswith('CE'):
+            return 'ce'
         elif device_name.startswith('P') and len(device_name) > 1 and device_name[1].isdigit():
             return 'p'
         elif device_name.startswith('A') and len(device_name) > 1 and device_name[1].isdigit():
@@ -964,6 +967,19 @@ class TopologyAPIHandler(BaseHandler):
             return 'leaf'
         else:
             return 'other'
+
+    @staticmethod
+    def extract_datacenter(device_name):
+        """
+        Extract datacenter identifier from device name.
+        E.g., 'spine1-DC1' -> 'DC1', 'leaf2-DC2' -> 'DC2', 'host1' -> ''
+        """
+        import re
+        # Match -DC followed by number or letter at end of name
+        match = re.search(r'-?(DC\d+|dc\d+)$', device_name, re.IGNORECASE)
+        if match:
+            return match.group(1).upper()
+        return ''  # No datacenter suffix
 
     @staticmethod
     def get_sort_key(device_name):
@@ -985,42 +1001,80 @@ class TopologyAPIHandler(BaseHandler):
     @staticmethod
     def calculate_positions(nodes_data):
         """
-        Calculate x,y positions for nodes based on tier and sorted order.
-        Organizes nodes in rows by device type, sorted by name within each row.
+        Calculate x,y positions for nodes based on tier, datacenter, and sorted order.
+        Organizes nodes in rows by device type, grouped by datacenter with spacing.
         """
-        # Group nodes by tier
+        import re
+
+        # Group nodes by tier, then by datacenter
         tiers = {}
         for node in nodes_data:
             device_type = node['data']['device_type']
             tier = TopologyAPIHandler.DEVICE_TIERS.get(device_type, 6)
-            if tier not in tiers:
-                tiers[tier] = []
-            tiers[tier].append(node)
+            dc = TopologyAPIHandler.extract_datacenter(node['data']['id'])
 
-        # Sort nodes within each tier by name (natural sort)
+            if tier not in tiers:
+                tiers[tier] = {}
+            if dc not in tiers[tier]:
+                tiers[tier][dc] = []
+            tiers[tier][dc].append(node)
+
+        # Sort nodes within each tier/dc group by name (natural sort)
         for tier in tiers:
-            tiers[tier].sort(key=lambda n: TopologyAPIHandler.get_sort_key(n['data']['id']))
+            for dc in tiers[tier]:
+                tiers[tier][dc].sort(key=lambda n: TopologyAPIHandler.get_sort_key(n['data']['id']))
 
         # Calculate positions
-        NODE_SPACING_X = 150  # Horizontal spacing between nodes
-        NODE_SPACING_Y = 120  # Vertical spacing between tiers
-        PADDING = 100         # Left padding
+        NODE_SPACING_X = 150   # Horizontal spacing between nodes
+        NODE_SPACING_Y = 120   # Vertical spacing between tiers
+        DC_SPACING = 80        # Extra spacing between datacenter groups
+        PADDING = 100          # Left padding
 
-        # Find the widest tier to center others
-        max_width = max(len(nodes) for nodes in tiers.values()) if tiers else 1
+        # Calculate max width considering DC groups and spacing
+        max_width = 0
+        for tier in tiers:
+            tier_width = 0
+            dc_keys = sorted(tiers[tier].keys())  # Sort DCs: '', 'DC1', 'DC2', etc.
+            for i, dc in enumerate(dc_keys):
+                tier_width += len(tiers[tier][dc]) * NODE_SPACING_X
+                if i < len(dc_keys) - 1:  # Add DC spacing between groups
+                    tier_width += DC_SPACING
+            max_width = max(max_width, tier_width)
 
+        if max_width == 0:
+            max_width = NODE_SPACING_X
+
+        # Position nodes
         for tier_num in sorted(tiers.keys()):
-            tier_nodes = tiers[tier_num]
-            tier_width = len(tier_nodes)
+            tier_dcs = tiers[tier_num]
+            dc_keys = sorted(tier_dcs.keys())  # Sort: '', 'DC1', 'DC2', 'DC3'
 
-            # Center this tier relative to the widest tier
-            start_x = PADDING + (max_width - tier_width) * NODE_SPACING_X / 2
+            # Calculate this tier's total width
+            tier_width = 0
+            for i, dc in enumerate(dc_keys):
+                tier_width += len(tier_dcs[dc]) * NODE_SPACING_X
+                if i < len(dc_keys) - 1:
+                    tier_width += DC_SPACING
 
-            for i, node in enumerate(tier_nodes):
-                node['position'] = {
-                    'x': start_x + i * NODE_SPACING_X,
-                    'y': PADDING + tier_num * NODE_SPACING_Y
-                }
+            # Center this tier
+            start_x = PADDING + (max_width - tier_width) / 2
+            current_x = start_x
+
+            for i, dc in enumerate(dc_keys):
+                dc_nodes = tier_dcs[dc]
+
+                for node in dc_nodes:
+                    node['position'] = {
+                        'x': current_x,
+                        'y': PADDING + tier_num * NODE_SPACING_Y
+                    }
+                    # Store DC info for potential UI use
+                    node['data']['datacenter'] = dc if dc else 'default'
+                    current_x += NODE_SPACING_X
+
+                # Add spacing after each DC group (except last)
+                if i < len(dc_keys) - 1:
+                    current_x += DC_SPACING
 
         return nodes_data
 

--- a/nested-labvm/atd-docker/uilanding/src/uilanding.py
+++ b/nested-labvm/atd-docker/uilanding/src/uilanding.py
@@ -925,6 +925,7 @@ class TopologyAPIHandler(BaseHandler):
         'spine': 3,
         'leaf': 4,
         'host': 5,
+        'customer': 5,
         'oob': 5,
         'other': 6
     }
@@ -959,6 +960,9 @@ class TopologyAPIHandler(BaseHandler):
             return 'ce'
         elif device_name.startswith('P') and len(device_name) > 1 and device_name[1].isdigit():
             return 'p'
+        # Customer devices: A1, A2, B1, B2, C1, C2, D1, D2, etc.
+        elif device_name[0] in ('A', 'B', 'C', 'D') and len(device_name) > 1 and device_name[1].isdigit():
+            return 'customer'
         else:
             return 'other'
 
@@ -1070,7 +1074,7 @@ class TopologyAPIHandler(BaseHandler):
                 p_routers.append(node)
             elif dtype == 'pe':
                 pe_routers.append(node)
-            elif dtype in ('ce', 'host', 'leaf', 'other'):
+            elif dtype in ('ce', 'host', 'leaf', 'customer', 'other'):
                 customer_devices.append(node)
             else:
                 other_devices.append(node)
@@ -1481,6 +1485,9 @@ class DevicesAPIHandler(BaseHandler):
                 ('Host', ['Host']),
                 ('Core', ['Core', 'DCI']),
                 ('ISP', ['ISP', 'Internet']),
+                ('PE Routers', ['PE']),
+                ('P Routers', ['P']),
+                ('Customer', []),  # Special handling for A, B, C, D prefixed devices
             ]
 
             # Group devices
@@ -1489,17 +1496,36 @@ class DevicesAPIHandler(BaseHandler):
 
             for device_name, device_info in nodes.items():
                 matched = False
-                for group_name, prefixes in group_patterns:
-                    for prefix in prefixes:
-                        if device_name.startswith(prefix) or prefix in device_name:
-                            groups[group_name].append({
-                                'name': device_name,
-                                'ip': device_info.get('ip', ''),
-                            })
-                            matched = True
+
+                # Special handling for Customer devices (A1, B1, C1, D1, etc.)
+                if len(device_name) > 1 and device_name[0] in ('A', 'B', 'C', 'D') and device_name[1].isdigit():
+                    groups['Customer'].append({
+                        'name': device_name,
+                        'ip': device_info.get('ip', ''),
+                    })
+                    matched = True
+
+                # Special handling for P routers (P1, P2, etc. but not PE)
+                elif device_name.startswith('P') and len(device_name) > 1 and device_name[1].isdigit():
+                    groups['P Routers'].append({
+                        'name': device_name,
+                        'ip': device_info.get('ip', ''),
+                    })
+                    matched = True
+
+                # Check other patterns
+                if not matched:
+                    for group_name, prefixes in group_patterns:
+                        for prefix in prefixes:
+                            if prefix and (device_name.startswith(prefix) or prefix in device_name):
+                                groups[group_name].append({
+                                    'name': device_name,
+                                    'ip': device_info.get('ip', ''),
+                                })
+                                matched = True
+                                break
+                        if matched:
                             break
-                    if matched:
-                        break
 
                 if not matched:
                     groups['Other'].append({

--- a/nested-labvm/atd-docker/uilanding/src/uilanding.py
+++ b/nested-labvm/atd-docker/uilanding/src/uilanding.py
@@ -913,21 +913,29 @@ class TopologyAPIHandler(BaseHandler):
     CACHE_TTL = 30
 
     # Device type to tier mapping (lower tier = higher in diagram)
+    # Tier 0: Internet (top, cloud/WAN edge)
+    # Tier 1: ISP cores (grouped by provider: ISP1, ISP2, etc.)
+    # Tier 2: DCI, core, P routers (inter-DC connectivity)
+    # Tier 3: Borderleaf, PE, CE (DC edge)
+    # Tier 4: Spines
+    # Tier 5: Leafs
+    # Tier 6: Hosts, customers, OOB
+    # Tier 7: Other
     DEVICE_TIERS = {
         'internet': 0,
-        'isp': 0,
-        'core': 1,
-        'dci': 1,
-        'p': 1,
-        'borderleaf': 2,
-        'pe': 2,
-        'ce': 2,
-        'spine': 3,
-        'leaf': 4,
-        'host': 5,
-        'customer': 5,
-        'oob': 5,
-        'other': 6
+        'isp': 1,
+        'core': 2,
+        'dci': 2,
+        'p': 2,
+        'borderleaf': 3,
+        'pe': 3,
+        'ce': 3,
+        'spine': 4,
+        'leaf': 5,
+        'host': 6,
+        'customer': 6,
+        'oob': 6,
+        'other': 7
     }
 
     @staticmethod
@@ -978,6 +986,20 @@ class TopologyAPIHandler(BaseHandler):
         if match:
             return match.group(1).upper()
         return ''  # No datacenter suffix
+
+    @staticmethod
+    def extract_isp_provider(device_name):
+        """
+        Extract ISP provider identifier from device name.
+        E.g., 'core1-ISP1' -> 'ISP1', 'core2-ISP2' -> 'ISP2', 'internet' -> ''
+        Used for grouping ISP devices by provider in the topology layout.
+        """
+        import re
+        # Match -ISP followed by number
+        match = re.search(r'-?(ISP\d+)$', device_name, re.IGNORECASE)
+        if match:
+            return match.group(1).upper()
+        return ''  # No ISP suffix
 
     @staticmethod
     def get_sort_key(device_name):
@@ -1187,23 +1209,30 @@ class TopologyAPIHandler(BaseHandler):
             return TopologyAPIHandler.calculate_wan_positions(nodes_data, edges_data)
 
         # Standard datacenter layout (tier-based)
-        # Group nodes by tier, then by datacenter
+        # Group nodes by tier, then by grouping key (datacenter or ISP provider)
         tiers = {}
+        ISP_TIER = TopologyAPIHandler.DEVICE_TIERS.get('isp', 1)
+
         for node in nodes_data:
             device_type = node['data']['device_type']
-            tier = TopologyAPIHandler.DEVICE_TIERS.get(device_type, 6)
-            dc = TopologyAPIHandler.extract_datacenter(node['data']['id'])
+            tier = TopologyAPIHandler.DEVICE_TIERS.get(device_type, 7)
+
+            # For ISP tier, group by ISP provider (ISP1, ISP2) instead of datacenter
+            if tier == ISP_TIER:
+                group_key = TopologyAPIHandler.extract_isp_provider(node['data']['id'])
+            else:
+                group_key = TopologyAPIHandler.extract_datacenter(node['data']['id'])
 
             if tier not in tiers:
                 tiers[tier] = {}
-            if dc not in tiers[tier]:
-                tiers[tier][dc] = []
-            tiers[tier][dc].append(node)
+            if group_key not in tiers[tier]:
+                tiers[tier][group_key] = []
+            tiers[tier][group_key].append(node)
 
-        # Sort nodes within each tier/dc group by name (natural sort)
+        # Sort nodes within each tier/group by name (natural sort)
         for tier in tiers:
-            for dc in tiers[tier]:
-                tiers[tier][dc].sort(key=lambda n: TopologyAPIHandler.get_sort_key(n['data']['id']))
+            for group_key in tiers[tier]:
+                tiers[tier][group_key].sort(key=lambda n: TopologyAPIHandler.get_sort_key(n['data']['id']))
 
         # Calculate positions
         NODE_SPACING_X = 150   # Horizontal spacing between nodes
@@ -1211,50 +1240,55 @@ class TopologyAPIHandler(BaseHandler):
         DC_SPACING = 80        # Extra spacing between datacenter groups
         PADDING = 100          # Left padding
 
-        # Calculate max width considering DC groups and spacing
+        # Calculate max width considering groups and spacing
+        # Groups can be DCs (DC1, DC2) or ISP providers (ISP1, ISP2) depending on tier
         max_width = 0
         for tier in tiers:
             tier_width = 0
-            dc_keys = sorted(tiers[tier].keys())  # Sort DCs: '', 'DC1', 'DC2', etc.
-            for i, dc in enumerate(dc_keys):
-                tier_width += len(tiers[tier][dc]) * NODE_SPACING_X
-                if i < len(dc_keys) - 1:  # Add DC spacing between groups
+            group_keys = sorted(tiers[tier].keys())  # Sort: '', 'DC1', 'DC2' or 'ISP1', 'ISP2'
+            for i, gk in enumerate(group_keys):
+                tier_width += len(tiers[tier][gk]) * NODE_SPACING_X
+                if i < len(group_keys) - 1:  # Add spacing between groups
                     tier_width += DC_SPACING
             max_width = max(max_width, tier_width)
 
         if max_width == 0:
             max_width = NODE_SPACING_X
 
-        # Position nodes
+        # Position nodes by tier
         for tier_num in sorted(tiers.keys()):
-            tier_dcs = tiers[tier_num]
-            dc_keys = sorted(tier_dcs.keys())  # Sort: '', 'DC1', 'DC2', 'DC3'
+            tier_groups = tiers[tier_num]
+            group_keys = sorted(tier_groups.keys())  # Sort: '', 'DC1', 'DC2' or 'ISP1', 'ISP2'
 
             # Calculate this tier's total width
             tier_width = 0
-            for i, dc in enumerate(dc_keys):
-                tier_width += len(tier_dcs[dc]) * NODE_SPACING_X
-                if i < len(dc_keys) - 1:
+            for i, gk in enumerate(group_keys):
+                tier_width += len(tier_groups[gk]) * NODE_SPACING_X
+                if i < len(group_keys) - 1:
                     tier_width += DC_SPACING
 
             # Center this tier
             start_x = PADDING + (max_width - tier_width) / 2
             current_x = start_x
 
-            for i, dc in enumerate(dc_keys):
-                dc_nodes = tier_dcs[dc]
+            for i, group_key in enumerate(group_keys):
+                group_nodes = tier_groups[group_key]
 
-                for node in dc_nodes:
+                for node in group_nodes:
                     node['position'] = {
                         'x': current_x,
                         'y': PADDING + tier_num * NODE_SPACING_Y
                     }
-                    # Store DC info for potential UI use
-                    node['data']['datacenter'] = dc if dc else 'default'
+                    # Store grouping info for potential UI use
+                    if tier_num == ISP_TIER:
+                        node['data']['isp_provider'] = group_key if group_key else 'default'
+                        node['data']['datacenter'] = 'shared'  # ISP devices are shared across DCs
+                    else:
+                        node['data']['datacenter'] = group_key if group_key else 'default'
                     current_x += NODE_SPACING_X
 
-                # Add spacing after each DC group (except last)
-                if i < len(dc_keys) - 1:
+                # Add spacing after each group (except last)
+                if i < len(group_keys) - 1:
                     current_x += DC_SPACING
 
         return nodes_data

--- a/nested-labvm/atd-docker/uilanding/src/uilanding.py
+++ b/nested-labvm/atd-docker/uilanding/src/uilanding.py
@@ -912,6 +912,22 @@ class TopologyAPIHandler(BaseHandler):
     _cache_lock = threading.Lock()
     CACHE_TTL = 30
 
+    # Device type to tier mapping (lower tier = higher in diagram)
+    DEVICE_TIERS = {
+        'internet': 0,
+        'isp': 0,
+        'core': 1,
+        'dci': 1,
+        'spine': 2,
+        'pe': 2,
+        'p': 3,
+        'borderleaf': 3,
+        'leaf': 4,
+        'oob': 5,
+        'host': 5,
+        'other': 6
+    }
+
     @staticmethod
     def classify_device_type(device_name):
         """Classify device type based on naming pattern."""
@@ -948,6 +964,65 @@ class TopologyAPIHandler(BaseHandler):
             return 'leaf'
         else:
             return 'other'
+
+    @staticmethod
+    def get_sort_key(device_name):
+        """
+        Generate a sort key for natural ordering of device names.
+        E.g., spine1, spine2, spine10 sorts correctly (not spine1, spine10, spine2)
+        """
+        import re
+        # Split name into text and number parts
+        parts = re.split(r'(\d+)', device_name)
+        result = []
+        for part in parts:
+            if part.isdigit():
+                result.append(int(part))
+            else:
+                result.append(part.lower())
+        return result
+
+    @staticmethod
+    def calculate_positions(nodes_data):
+        """
+        Calculate x,y positions for nodes based on tier and sorted order.
+        Organizes nodes in rows by device type, sorted by name within each row.
+        """
+        # Group nodes by tier
+        tiers = {}
+        for node in nodes_data:
+            device_type = node['data']['device_type']
+            tier = TopologyAPIHandler.DEVICE_TIERS.get(device_type, 6)
+            if tier not in tiers:
+                tiers[tier] = []
+            tiers[tier].append(node)
+
+        # Sort nodes within each tier by name (natural sort)
+        for tier in tiers:
+            tiers[tier].sort(key=lambda n: TopologyAPIHandler.get_sort_key(n['data']['id']))
+
+        # Calculate positions
+        NODE_SPACING_X = 150  # Horizontal spacing between nodes
+        NODE_SPACING_Y = 120  # Vertical spacing between tiers
+        PADDING = 100         # Left padding
+
+        # Find the widest tier to center others
+        max_width = max(len(nodes) for nodes in tiers.values()) if tiers else 1
+
+        for tier_num in sorted(tiers.keys()):
+            tier_nodes = tiers[tier_num]
+            tier_width = len(tier_nodes)
+
+            # Center this tier relative to the widest tier
+            start_x = PADDING + (max_width - tier_width) * NODE_SPACING_X / 2
+
+            for i, node in enumerate(tier_nodes):
+                node['position'] = {
+                    'x': start_x + i * NODE_SPACING_X,
+                    'y': PADDING + tier_num * NODE_SPACING_Y
+                }
+
+        return nodes_data
 
     def parse_topology(self, topo_path):
         """
@@ -1074,6 +1149,9 @@ class TopologyAPIHandler(BaseHandler):
                     },
                     'classes': f"device-type-{device_type} status-unknown"
                 })
+
+        # Calculate positions based on device type tiers and natural name sorting
+        nodes = self.calculate_positions(nodes)
 
         return {
             'data': {

--- a/nested-labvm/atd-docker/uilanding/src/uilanding.py
+++ b/nested-labvm/atd-docker/uilanding/src/uilanding.py
@@ -17,6 +17,7 @@ import traceback
 import os
 import subprocess
 import time
+import threading
 
 # Disable any TLS Warnings when getting instance Uptime
 urllib3.disable_warnings()
@@ -902,6 +903,240 @@ class TerminalPageHandler(BaseHandler):
         )
 
 
+class TopologyAPIHandler(BaseHandler):
+    """API endpoint to return topology data for interactive Cytoscape.js diagram."""
+
+    # Thread-safe cache for parsed topology data (30 second TTL)
+    _cache = {}
+    _cache_time = 0
+    _cache_lock = threading.Lock()
+    CACHE_TTL = 30
+
+    @staticmethod
+    def classify_device_type(device_name):
+        """Classify device type based on naming pattern."""
+        name_lower = device_name.lower()
+
+        # Order matters: more specific patterns first
+        if 'borderleaf' in name_lower or device_name.startswith('BL'):
+            return 'borderleaf'
+        elif 'spine' in name_lower:
+            return 'spine'
+        elif 'leaf' in name_lower:
+            return 'leaf'
+        elif 'host' in name_lower:
+            return 'host'
+        elif 'dci' in name_lower or device_name == 'DCI':
+            return 'dci'
+        elif 'internet' in name_lower:
+            return 'internet'
+        elif 'isp' in name_lower:
+            return 'isp'
+        elif 'core' in name_lower:
+            return 'core'
+        elif 'oob' in name_lower:
+            return 'oob'
+        elif device_name.startswith('PE'):
+            return 'pe'
+        elif device_name.startswith('P') and len(device_name) > 1 and device_name[1].isdigit():
+            return 'p'
+        elif device_name.startswith('A') and len(device_name) > 1 and device_name[1].isdigit():
+            return 'leaf'
+        elif device_name.startswith('B') and len(device_name) > 1 and device_name[1].isdigit():
+            return 'leaf'
+        elif device_name.startswith('C') and len(device_name) > 1 and device_name[1].isdigit():
+            return 'leaf'
+        else:
+            return 'other'
+
+    def parse_topology(self, topo_path):
+        """
+        Parse topo_build.yml and return Cytoscape.js formatted data.
+
+        Returns:
+            dict: Success with 'data' key containing topology
+            dict: Error with 'error' and 'error_type' keys
+        """
+        # Try to open and parse the file
+        try:
+            with open(topo_path, 'r') as f:
+                topo_data = YAML().load(f)
+        except FileNotFoundError:
+            return {'error': f'Topology file not found: {topo_path}', 'error_type': 'not_found'}
+        except PermissionError:
+            return {'error': f'Permission denied accessing: {topo_path}', 'error_type': 'permission'}
+        except Exception as e:
+            pS(f"Error parsing topology file: {e}")
+            return {'error': f'Failed to parse topology file: {str(e)}', 'error_type': 'parse_error'}
+
+        # Validate topo_data structure
+        if topo_data is None:
+            return {'error': 'Topology file is empty', 'error_type': 'empty_file'}
+
+        if 'nodes' not in topo_data:
+            return {'error': 'Topology file missing "nodes" key', 'error_type': 'invalid_format'}
+
+        if not topo_data['nodes']:
+            # Empty nodes list - return empty topology (valid case)
+            pS("Warning: Topology file has no nodes")
+            return {
+                'data': {
+                    'metadata': {
+                        'topology_name': TOPO,
+                        'node_count': 0,
+                        'edge_count': 0,
+                        'generated_at': datetime.now().isoformat()
+                    },
+                    'nodes': [],
+                    'edges': []
+                }
+            }
+
+        nodes = []
+        edges = []
+        edge_set = set()  # Track edges to avoid duplicates
+
+        for node_entry in topo_data['nodes']:
+            # Validate node entry is a dict
+            if not isinstance(node_entry, dict):
+                pS(f"Warning: Invalid node entry format (not a dict): {node_entry}")
+                continue
+
+            # Each entry is a dict with device name as key
+            for device_name, device_info in node_entry.items():
+                # Validate device_info is a dict
+                if not isinstance(device_info, dict):
+                    pS(f"Warning: Invalid device info for {device_name} (not a dict)")
+                    continue
+
+                device_type = self.classify_device_type(device_name)
+                ip_addr = device_info.get('ip_addr', 'N/A')
+                sys_mac = device_info.get('sys_mac', 'N/A')
+                neighbors = device_info.get('neighbors', [])
+
+                # Validate neighbors is a list
+                if not isinstance(neighbors, list):
+                    pS(f"Warning: Invalid neighbors format for {device_name}")
+                    neighbors = []
+
+                # Build port info for tooltip
+                ports = []
+                for neighbor in neighbors:
+                    if not isinstance(neighbor, dict):
+                        continue
+
+                    ports.append({
+                        'port': neighbor.get('port', ''),
+                        'neighbor': neighbor.get('neighborDevice', ''),
+                        'neighbor_port': neighbor.get('neighborPort', '')
+                    })
+
+                    # Create edge (deduplicate by sorting node names)
+                    neighbor_device = neighbor.get('neighborDevice', '')
+                    if neighbor_device:
+                        edge_key = tuple(sorted([device_name, neighbor_device]))
+                        if edge_key not in edge_set:
+                            edge_set.add(edge_key)
+                            source_port = neighbor.get('port', '')
+                            target_port = neighbor.get('neighborPort', '')
+                            edges.append({
+                                'data': {
+                                    'id': f"{device_name}-{neighbor_device}",
+                                    'source': device_name,
+                                    'target': neighbor_device,
+                                    'source_port': source_port,
+                                    'target_port': target_port,
+                                    'label': f"{source_port} ↔ {target_port}" if source_port and target_port else ''
+                                }
+                            })
+
+                # Create node
+                nodes.append({
+                    'data': {
+                        'id': device_name,
+                        'label': device_name,
+                        'ip': ip_addr,
+                        'sys_mac': sys_mac,
+                        'device_type': device_type,
+                        'status': 'unknown',
+                        'ports': ports
+                    },
+                    'classes': f"device-type-{device_type} status-unknown"
+                })
+
+        return {
+            'data': {
+                'metadata': {
+                    'topology_name': TOPO,
+                    'node_count': len(nodes),
+                    'edge_count': len(edges),
+                    'generated_at': datetime.now().isoformat()
+                },
+                'nodes': nodes,
+                'edges': edges
+            }
+        }
+
+    def options(self):
+        """Handle CORS preflight requests."""
+        self.set_header("Access-Control-Allow-Origin", "*")
+        self.set_header("Access-Control-Allow-Methods", "GET, OPTIONS")
+        self.set_header("Access-Control-Allow-Headers", "Content-Type, Authorization")
+        self.set_header("Access-Control-Max-Age", "86400")  # Cache preflight for 24 hours
+        self.set_status(204)
+        self.finish()
+
+    def get(self):
+        if not self.current_user:
+            self.set_status(401)
+            self.write(json.dumps({'error': 'Authentication required'}))
+            return
+
+        self.set_header("Content-Type", "application/json")
+        self.set_header("Access-Control-Allow-Origin", "*")
+
+        try:
+            current_time = time.time()
+
+            # Thread-safe cache check
+            with TopologyAPIHandler._cache_lock:
+                if (TopologyAPIHandler._cache and
+                    current_time - TopologyAPIHandler._cache_time < TopologyAPIHandler.CACHE_TTL):
+                    self.write(json.dumps(TopologyAPIHandler._cache))
+                    return
+
+            # Parse topology file (outside lock to avoid blocking)
+            topo_path = f"/opt/atd/topologies/{TOPO}/topo_build.yml"
+            result = self.parse_topology(topo_path)
+
+            # Check for errors
+            if 'error' in result:
+                error_type = result.get('error_type', 'unknown')
+                if error_type == 'not_found':
+                    self.set_status(404)
+                elif error_type == 'permission':
+                    self.set_status(403)
+                else:
+                    self.set_status(500)
+                self.write(json.dumps({'error': result['error']}))
+                return
+
+            topology_data = result['data']
+
+            # Thread-safe cache update
+            with TopologyAPIHandler._cache_lock:
+                TopologyAPIHandler._cache = topology_data
+                TopologyAPIHandler._cache_time = current_time
+
+            self.write(json.dumps(topology_data))
+
+        except Exception as e:
+            pS(f"Error in TopologyAPIHandler: {e}")
+            traceback.print_exc()
+            self.set_status(500)
+            self.write(json.dumps({'error': f'Internal server error: {str(e)}'}))
+
+
 class DevicesAPIHandler(BaseHandler):
     """API endpoint to return device list grouped by type for terminal page."""
 
@@ -1058,6 +1293,7 @@ if __name__ == "__main__":
         (r'/baseUrl', BaseUrlHandler),
         (r'/terminal', TerminalPageHandler),
         (r'/td-api/devices', DevicesAPIHandler),
+        (r'/td-api/topology', TopologyAPIHandler),
     ], **settings)
     app.listen(PORT)
     print('*** Websocket Server Started on {} ***'.format(PORT))

--- a/nested-labvm/atd-docker/uilanding/src/uilanding.py
+++ b/nested-labvm/atd-docker/uilanding/src/uilanding.py
@@ -996,6 +996,14 @@ class TopologyAPIHandler(BaseHandler):
         edges = []
         edge_set = set()  # Track edges to avoid duplicates
 
+        # First pass: collect all valid node names
+        valid_node_names = set()
+        for node_entry in topo_data['nodes']:
+            if isinstance(node_entry, dict):
+                for device_name in node_entry.keys():
+                    valid_node_names.add(device_name)
+
+        # Second pass: build nodes and edges
         for node_entry in topo_data['nodes']:
             # Validate node entry is a dict
             if not isinstance(node_entry, dict):
@@ -1025,15 +1033,16 @@ class TopologyAPIHandler(BaseHandler):
                     if not isinstance(neighbor, dict):
                         continue
 
+                    neighbor_device = neighbor.get('neighborDevice', '')
+
                     ports.append({
                         'port': neighbor.get('port', ''),
-                        'neighbor': neighbor.get('neighborDevice', ''),
+                        'neighbor': neighbor_device,
                         'neighbor_port': neighbor.get('neighborPort', '')
                     })
 
-                    # Create edge (deduplicate by sorting node names)
-                    neighbor_device = neighbor.get('neighborDevice', '')
-                    if neighbor_device:
+                    # Create edge only if both nodes exist (prevents Cytoscape.js errors)
+                    if neighbor_device and neighbor_device in valid_node_names:
                         edge_key = tuple(sorted([device_name, neighbor_device]))
                         if edge_key not in edge_set:
                             edge_set.add(edge_key)
@@ -1049,6 +1058,8 @@ class TopologyAPIHandler(BaseHandler):
                                     'label': f"{source_port} ↔ {target_port}" if source_port and target_port else ''
                                 }
                             })
+                    elif neighbor_device:
+                        pS(f"Warning: Skipping edge {device_name}->{neighbor_device}: target node not in topology")
 
                 # Create node
                 nodes.append({


### PR DESCRIPTION
  ---
  Summary

  - Interactive topology is now the default view on the home page, replacing the static image as the primary topology display
  - Added interactive topology to the terminal page side panel, replacing the static image with a fully functional Cytoscape.js diagram
  - Improved ISP device layout for multi-datacenter topologies (L5, L7) - ISP cores now have their own tier and are grouped by provider (ISP1, ISP2, etc.)
  - Fixed tooltip visibility - connection links and status text now use darker colours for better readability on white backgrounds
  - Terminal page SSH integration - clicking "Open Terminal" in the topology context menu now opens devices in the current terminal page's tabs instead of a new window

  Test plan

  - Verify interactive topology loads by default on home page
  - Verify "Switch to Static" button toggles to static image view
  - Open terminal page and click "Topology" button to open side panel
  - Verify interactive topology loads in the terminal side panel
  - Right-click a device and select "Open Terminal" - verify it opens in current page tabs
  - Hover over devices and verify tooltip text is clearly readable
  - Test with L5 or L7 topology to verify ISP devices are grouped correctly (ISP1 devices together, ISP2 devices together)
  - Verify search, reset, and fit buttons work in terminal page topology panel