### PR TITLE
Make static image default

### DIFF
--- a/nested-labvm/atd-docker/uilanding/src/html/index.html
+++ b/nested-labvm/atd-docker/uilanding/src/html/index.html
@@ -252,9 +252,9 @@
                   <!-- View Toggle -->
                   <div class="topology-controls">
                     <button id="toggle-topo-view" class="button">
-                      <i class="fa-solid fa-image"></i> Switch to Static
+                      <i class="fa-solid fa-diagram-project"></i> Switch to Interactive (Beta)
                     </button>
-                    <div id="filter-controls">
+                    <div id="filter-controls" style="display: none;">
                       <input type="text" id="device-search" placeholder="Search devices..." />
                       <div id="device-type-filters"></div>
                       <button id="reset-layout" class="button">Reset Layout</button>
@@ -262,13 +262,13 @@
                     </div>
                   </div>
 
-                  <!-- Static Topology (hidden by default) -->
-                  <div id="static-topology" class="text-center" style="display: none;">
+                  <!-- Static Topology (default view) -->
+                  <div id="static-topology" class="text-center" style="display: block;">
                     <img src="topo/atd-topo.png" usemap="#image_map" />
                   </div>
 
-                  <!-- Interactive Topology (default view) -->
-                  <div id="interactive-topology"></div>
+                  <!-- Interactive Topology (hidden by default) -->
+                  <div id="interactive-topology" style="display: none;"></div>
 
                 </div>
               </div>
@@ -458,7 +458,7 @@
     import { TopologyManager } from './js/topology/topology-manager.js';
 
     let topoManager = null;
-    let isInteractiveView = true;  // Start with interactive view
+    let isInteractiveView = false;  // Start with static view
 
     // Store observer reference for cleanup
     let capturePanelObserver = null;
@@ -581,7 +581,7 @@
         staticDiv.style.display = 'block';
         interactiveDiv.style.display = 'none';
         filterControls.style.display = 'none';
-        toggleBtn.innerHTML = '<i class="fa-solid fa-diagram-project"></i> Switch to Interactive';
+        toggleBtn.innerHTML = '<i class="fa-solid fa-diagram-project"></i> Switch to Interactive (Beta)';
 
         isInteractiveView = false;
       } else {

--- a/nested-labvm/atd-docker/uilanding/src/uilanding.py
+++ b/nested-labvm/atd-docker/uilanding/src/uilanding.py
@@ -204,30 +204,38 @@ class topoRequestHandler(BaseHandler):
     def get(self):
         host_yaml = YAML().load(open(ATD_ACCESS_PATH, 'r'))
         lab_type = host_yaml.get('customer_details', {}).get('lab_type', 'Lab')
-        if lab_type == "Exam" and 'auth' in self.request.arguments and 'honorlock' not in self.request.arguments:
-            # Exam access without honorlock parameter - redirect to exam authentication
-            # This ensures ExamSessionGuard (in honorlock-index.html) runs to detect multi-tab scenarios
-            # Note: We don't check self.current_user here because:
-            #   1. Session cookies persist even after tabs close
-            #   2. Only frontend localStorage heartbeat can reliably detect active tabs
-            #   3. ExamSessionGuard will handle multi-tab detection properly
-            self.redirect('/exam-authentication')
-            return()
-        if not self.current_user:
-            if lab_type == "Exam":
 
-                if 'auth' in self.request.arguments and 'honorlock' in self.request.arguments:
-                    self.redirect('/login?auth={0}'.format(self.get_argument('auth')))
-                elif 'auth' in self.request.arguments:
-                    self.redirect('/exam-authentication')
-                else:
-                    self.redirect('/login')
+        # For Exam labs: ALWAYS require Honorlock authentication flow
+        # This prevents bypass via direct URL access or cached sessions
+        if lab_type == "Exam":
+            # Check if user accessed via proper Honorlock flow (has 'honorlock' parameter)
+            if 'honorlock' in self.request.arguments:
+                # Valid Honorlock flow - proceed with authentication
+                if not self.current_user:
+                    # Redirect to login with auth credentials
+                    if 'auth' in self.request.arguments:
+                        self.redirect('/login?auth={0}'.format(self.get_argument('auth')))
+                    else:
+                        self.redirect('/login')
+                    return()
+                # else: User authenticated via Honorlock - allow access (continue to line 232+)
             else:
-                if 'auth' in self.request.arguments:
-                    self.redirect('/login?auth={0}'.format(self.get_argument('auth')))
-                else:
-                    self.redirect('/login')
+                # No 'honorlock' parameter - force Honorlock authentication
+                # This blocks:
+                #   1. Direct URL access: https://lab.com/
+                #   2. Cached session access without Honorlock
+                #   3. Manual auth parameter manipulation
+                self.redirect('/exam-authentication')
+                return()
 
+        # Handle non-authenticated users for regular (non-Exam) labs
+        # Note: Exam labs are already handled above (lines 210-229)
+        if not self.current_user:
+            # Regular lab authentication
+            if 'auth' in self.request.arguments:
+                self.redirect('/login?auth={0}'.format(self.get_argument('auth')))
+            else:
+                self.redirect('/login')
             return()
         else:
             _topo_cvp = False

--- a/nested-labvm/atd-docker/uilanding/src/uilanding.py
+++ b/nested-labvm/atd-docker/uilanding/src/uilanding.py
@@ -205,10 +205,19 @@ class topoRequestHandler(BaseHandler):
         host_yaml = YAML().load(open(ATD_ACCESS_PATH, 'r'))
         lab_type = host_yaml.get('customer_details', {}).get('lab_type', 'Lab')
         if lab_type == "Exam" and 'auth' in self.request.arguments and 'honorlock' not in self.request.arguments:
+            # If user already has a session, don't disrupt it
+            # This prevents Tab B from killing Tab A's session
+            if self.current_user:
+                # User already authenticated - show "exam already running" page
+                # This prevents Tab B from loading the exam while Tab A is active
+                self.redirect('/exam-already-running')
+                return()
+
+            # No active session - proceed with Honorlock auth (first-time access)
             # Clear authentication and force re-authentication through Honorlock
             self.clear_cookie("user")
             self.redirect('/exam-authentication')
-            return()        
+            return()
         if not self.current_user:
             if lab_type == "Exam":
 

--- a/nested-labvm/atd-docker/uilanding/src/uilanding.py
+++ b/nested-labvm/atd-docker/uilanding/src/uilanding.py
@@ -205,17 +205,12 @@ class topoRequestHandler(BaseHandler):
         host_yaml = YAML().load(open(ATD_ACCESS_PATH, 'r'))
         lab_type = host_yaml.get('customer_details', {}).get('lab_type', 'Lab')
         if lab_type == "Exam" and 'auth' in self.request.arguments and 'honorlock' not in self.request.arguments:
-            # If user already has a session, don't disrupt it
-            # This prevents Tab B from killing Tab A's session
-            if self.current_user:
-                # User already authenticated - show "exam already running" page
-                # This prevents Tab B from loading the exam while Tab A is active
-                self.redirect('/exam-already-running')
-                return()
-
-            # No active session - proceed with Honorlock auth (first-time access)
-            # Clear authentication and force re-authentication through Honorlock
-            self.clear_cookie("user")
+            # Exam access without honorlock parameter - redirect to exam authentication
+            # This ensures ExamSessionGuard (in honorlock-index.html) runs to detect multi-tab scenarios
+            # Note: We don't check self.current_user here because:
+            #   1. Session cookies persist even after tabs close
+            #   2. Only frontend localStorage heartbeat can reliably detect active tabs
+            #   3. ExamSessionGuard will handle multi-tab detection properly
             self.redirect('/exam-authentication')
             return()
         if not self.current_user:


### PR DESCRIPTION
This pull request makes two main updates to the ATD Docker UI landing page: it changes the default topology view to the static image instead of the interactive view, and it strengthens the authentication flow for "Exam" labs to ensure all users are properly routed through Honorlock authentication. Below are the most important changes:

**UI/UX: Topology View Defaults and Controls**
- The default topology view is now the static topology image, with the interactive topology hidden by default. The toggle button label has been updated to indicate that the interactive view is in beta. Filter controls are also hidden initially. [[1]](diffhunk://#diff-fff5e0874935ba40090006b48538486bcc2ad74c57252e862d59c8e26de33c40L255-R271) [[2]](diffhunk://#diff-fff5e0874935ba40090006b48538486bcc2ad74c57252e862d59c8e26de33c40L461-R461) [[3]](diffhunk://#diff-fff5e0874935ba40090006b48538486bcc2ad74c57252e862d59c8e26de33c40L584-R584)

**Authentication Flow for Exam Labs**
- The authentication logic in `uilanding.py` for "Exam" labs has been refactored to always require the Honorlock authentication flow. This prevents users from bypassing Honorlock via direct URL access, cached sessions, or manual manipulation of authentication parameters. Only users coming through the proper Honorlock flow are allowed to proceed.