### PR TITLE
Feature/universal countdown timer

### DIFF
--- a/nested-labvm/atd-docker/docker-compose.yml
+++ b/nested-labvm/atd-docker/docker-compose.yml
@@ -85,7 +85,7 @@ services:
       - /opt/ceos:/opt/ceos:rw
   uilanding:
     container_name: atd-uilanding
-    image: us.gcr.io/atd-testdrivetraining-dev/atddocker_uilanding:1.0.27-honorlock
+    image: us.gcr.io/atd-testdrivetraining-dev/atddocker_uilanding:1.0.28-honorlock
     restart: always
     environment:
       - PYTHONUNBUFFERED=1
@@ -162,7 +162,7 @@ services:
       - "1813:1813/udp"
   nginx:
     container_name: atd-nginx
-    image: us.gcr.io/atd-testdrivetraining-dev/atddocker_nginx:1.0.11
+    image: us.gcr.io/atd-testdrivetraining-dev/atddocker_nginx:1.0.12
     restart: always
     depends_on:
       - uilanding

--- a/nested-labvm/atd-docker/nginx/Dockerfile
+++ b/nested-labvm/atd-docker/nginx/Dockerfile
@@ -2,6 +2,8 @@ FROM nginx:latest
 
 COPY src/atd.conf /etc/nginx/conf.d/
 
+COPY src/timer-widget.html /etc/nginx/timer-widget.html
+
 COPY src/atd-certs.sh /docker-entrypoint.d/
 
 RUN mkdir /etc/nginx/certs

--- a/nested-labvm/atd-docker/nginx/Dockerfile
+++ b/nested-labvm/atd-docker/nginx/Dockerfile
@@ -2,7 +2,7 @@ FROM nginx:latest
 
 COPY src/atd.conf /etc/nginx/conf.d/
 
-COPY src/timer-widget.html /etc/nginx/timer-widget.html
+COPY src/timer-widget.js /etc/nginx/timer-widget.js
 
 COPY src/atd-certs.sh /docker-entrypoint.d/
 

--- a/nested-labvm/atd-docker/nginx/src/atd.conf
+++ b/nested-labvm/atd-docker/nginx/src/atd.conf
@@ -93,6 +93,11 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
     }
+    location /timer-widget.html {
+        alias /etc/nginx/timer-widget.html;
+        add_header Content-Type "text/html";
+        add_header Cache-Control "no-cache, no-store, must-revalidate";
+    }
     location /coder/ {
         proxy_pass http://atd-coder:8080/;
         proxy_set_header X-Real-IP $remote_addr;
@@ -103,6 +108,11 @@ server {
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
         proxy_redirect off;
+
+        # === Timer Widget Injection ===
+        sub_filter '</body>' '<script src="/timer-widget.html"></script></body>';
+        sub_filter_once off;
+        proxy_set_header Accept-Encoding "";
     }
     location /ssh {
         proxy_pass http://atd-ssh:2222;

--- a/nested-labvm/atd-docker/nginx/src/atd.conf
+++ b/nested-labvm/atd-docker/nginx/src/atd.conf
@@ -45,6 +45,12 @@ server {
         proxy_set_header  X-Forwarded-For $remote_addr;
         proxy_set_header Authorization $http_authorization;
         proxy_pass_header  Authorization;
+
+        # === Timer Widget Injection ===
+        sub_filter '</body>' '<script src="/timer-widget.js"></script></body>';
+        sub_filter_types text/html;
+        sub_filter_once off;
+        proxy_set_header Accept-Encoding "";
     }
     location /host1 {
         proxy_pass http://192.168.0.1:6001/;
@@ -59,6 +65,12 @@ server {
         client_max_body_size 800M;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection $http_connection;
+
+        # === Timer Widget Injection ===
+        sub_filter '</body>' '<script src="/timer-widget.js"></script></body>';
+        sub_filter_types text/html;
+        sub_filter_once off;
+        proxy_set_header Accept-Encoding "";
     }
     location /host2 {
         proxy_pass http://192.168.0.1:6002/;
@@ -74,6 +86,11 @@ server {
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection $http_connection;
 
+        # === Timer Widget Injection ===
+        sub_filter '</body>' '<script src="/timer-widget.js"></script></body>';
+        sub_filter_types text/html;
+        sub_filter_once off;
+        proxy_set_header Accept-Encoding "";
     }
     location /uptime {
         access_log off;
@@ -86,6 +103,15 @@ server {
         proxy_set_header  X-Real-IP $remote_addr;
         proxy_set_header  X-Forwarded-For $remote_addr;
     }
+    location /uptimeWithRuntime {
+        access_log off;
+        proxy_pass http://atd-uilanding/uptimeWithRuntime;
+        proxy_http_version 1.1;
+        proxy_read_timeout 120;
+        proxy_set_header  Host $host;
+        proxy_set_header  X-Real-IP $remote_addr;
+        proxy_set_header  X-Forwarded-For $remote_addr;
+    }
     location /jenkins {
         proxy_pass http://atd-jenkins:8080;
         proxy_set_header Host $host;
@@ -93,9 +119,9 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
     }
-    location /timer-widget.html {
-        alias /etc/nginx/timer-widget.html;
-        add_header Content-Type "text/html";
+    location /timer-widget.js {
+        alias /etc/nginx/timer-widget.js;
+        add_header Content-Type "application/javascript";
         add_header Cache-Control "no-cache, no-store, must-revalidate";
     }
     location /coder/ {
@@ -110,7 +136,7 @@ server {
         proxy_redirect off;
 
         # === Timer Widget Injection ===
-        sub_filter '</body>' '<script src="/timer-widget.html"></script></body>';
+        sub_filter '</body>' '<script src="/timer-widget.js"></script></body>';
         sub_filter_types text/html text/plain;
         sub_filter_once off;
         proxy_set_header Accept-Encoding "";
@@ -124,6 +150,12 @@ server {
         proxy_set_header  Host $host;
         proxy_set_header  X-Real-IP $remote_addr;
         proxy_set_header  X-Forwarded-For $remote_addr;
+
+        # === Timer Widget Injection ===
+        sub_filter '</body>' '<script src="/timer-widget.js"></script></body>';
+        sub_filter_types text/html;
+        sub_filter_once off;
+        proxy_set_header Accept-Encoding "";
     }
     location = /firefox {return 301 $scheme://$http_host/firefox/;}
     location /firefox/ {
@@ -138,6 +170,12 @@ server {
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
         proxy_read_timeout 86400; # Keep connection open
+
+        # === Timer Widget Injection ===
+        sub_filter '</body>' '<script src="/timer-widget.js"></script></body>';
+        sub_filter_types text/html;
+        sub_filter_once off;
+        proxy_set_header Accept-Encoding "";
     }
     location ~ ^/(grpc-web/arista\..*|arista\..*) {
         grpc_pass grpcs://192.168.0.5:443;
@@ -159,5 +197,11 @@ server {
         client_max_body_size 800M;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection $http_connection;
+
+        # === Timer Widget Injection ===
+        sub_filter '</body>' '<script src="/timer-widget.js"></script></body>';
+        sub_filter_types text/html;
+        sub_filter_once off;
+        proxy_set_header Accept-Encoding "";
     }
   }

--- a/nested-labvm/atd-docker/nginx/src/atd.conf
+++ b/nested-labvm/atd-docker/nginx/src/atd.conf
@@ -111,6 +111,7 @@ server {
 
         # === Timer Widget Injection ===
         sub_filter '</body>' '<script src="/timer-widget.html"></script></body>';
+        sub_filter_types text/html text/plain;
         sub_filter_once off;
         proxy_set_header Accept-Encoding "";
     }

--- a/nested-labvm/atd-docker/nginx/src/timer-widget.html
+++ b/nested-labvm/atd-docker/nginx/src/timer-widget.html
@@ -1,0 +1,264 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        #atd-countdown-timer {
+            position: fixed;
+            top: 10px;
+            right: 10px;
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            color: white;
+            padding: 8px 16px;
+            border-radius: 6px;
+            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+            font-size: 14px;
+            font-weight: 600;
+            z-index: 999999;
+            box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+            min-width: 120px;
+            text-align: center;
+            user-select: none;
+            transition: all 0.3s ease;
+        }
+
+        #atd-countdown-timer:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 6px 16px rgba(0, 0, 0, 0.2);
+        }
+
+        #atd-countdown-timer.exam-mode {
+            background: linear-gradient(135deg, #f093fb 0%, #f5576c 100%);
+        }
+
+        #atd-countdown-timer.warning {
+            background: linear-gradient(135deg, #ff9a56 0%, #ff6a88 100%);
+            animation: pulse 2s infinite;
+        }
+
+        #atd-countdown-timer.expired {
+            background: linear-gradient(135deg, #ff6b6b 0%, #c92a2a 100%);
+        }
+
+        @keyframes pulse {
+            0%, 100% {
+                opacity: 1;
+            }
+            50% {
+                opacity: 0.8;
+            }
+        }
+
+        .timer-label {
+            font-size: 10px;
+            opacity: 0.9;
+            margin-bottom: 2px;
+            text-transform: uppercase;
+            letter-spacing: 0.5px;
+        }
+
+        .timer-value {
+            font-size: 18px;
+            font-weight: 700;
+            letter-spacing: 1px;
+            font-family: 'Courier New', monospace;
+        }
+
+        .timer-error {
+            font-size: 11px;
+            opacity: 0.9;
+        }
+    </style>
+</head>
+<body>
+    <div id="atd-countdown-timer">
+        <div class="timer-label">Time Remaining</div>
+        <div class="timer-value">--:--:--</div>
+    </div>
+
+    <script>
+        (function() {
+            'use strict';
+
+            const UPTIME_ENDPOINT = '/uptime';
+            const UPDATE_INTERVAL = 1000; // 1 second
+            const RETRY_DELAY = 5000; // 5 seconds on error
+            const WARNING_THRESHOLD = 300; // 5 minutes in seconds
+
+            let timerElement = document.getElementById('atd-countdown-timer');
+            let timerValue = timerElement.querySelector('.timer-value');
+            let timerLabel = timerElement.querySelector('.timer-label');
+            let updateInterval = null;
+            let isExamMode = false;
+            let examEndTime = null;
+            let labBoottime = null;
+            let labRuntime = null; // in hours
+
+            // Format seconds to HH:MM:SS
+            function formatTime(seconds) {
+                if (seconds < 0) return '00:00:00';
+
+                const hours = Math.floor(seconds / 3600);
+                const minutes = Math.floor((seconds % 3600) / 60);
+                const secs = Math.floor(seconds % 60);
+
+                return [
+                    String(hours).padStart(2, '0'),
+                    String(minutes).padStart(2, '0'),
+                    String(secs).padStart(2, '0')
+                ].join(':');
+            }
+
+            // Fetch timer data from uptime endpoint
+            async function fetchTimerData() {
+                try {
+                    const response = await fetch(UPTIME_ENDPOINT, {
+                        method: 'GET',
+                        headers: {
+                            'Accept': 'application/json'
+                        },
+                        cache: 'no-cache'
+                    });
+
+                    if (!response.ok) {
+                        throw new Error(`HTTP ${response.status}`);
+                    }
+
+                    const data = await response.json();
+                    return data;
+                } catch (error) {
+                    console.error('[ATD Timer] Failed to fetch timer data:', error);
+                    throw error;
+                }
+            }
+
+            // Check if exam mode is active (exam_end_time exists)
+            async function detectExamMode() {
+                try {
+                    // Try to fetch exam status from a separate endpoint if available
+                    // For now, we'll detect exam mode based on URL or other indicators
+                    // This is a placeholder - actual implementation may vary
+                    const urlParams = new URLSearchParams(window.location.search);
+                    if (urlParams.has('exam') || window.location.pathname.includes('/exam')) {
+                        isExamMode = true;
+                        timerElement.classList.add('exam-mode');
+                        timerLabel.textContent = 'Exam Time';
+                    }
+                } catch (error) {
+                    console.error('[ATD Timer] Failed to detect exam mode:', error);
+                }
+            }
+
+            // Calculate time remaining
+            function calculateTimeRemaining(data) {
+                const currentTime = Math.floor(Date.now() / 1000);
+                let timeRemaining = 0;
+
+                if (isExamMode && examEndTime) {
+                    // Exam mode: Use absolute end time
+                    timeRemaining = examEndTime - currentTime;
+                } else if (data.boottime) {
+                    // Normal lab mode: Use boottime + runtime
+                    // Assume runtime is 8 hours if not specified
+                    const runtime = labRuntime || 8;
+                    const expirationTime = data.boottime + (runtime * 60 * 60);
+                    timeRemaining = expirationTime - currentTime;
+                } else {
+                    throw new Error('Missing boottime data');
+                }
+
+                return timeRemaining;
+            }
+
+            // Update timer display
+            function updateTimer(timeRemaining) {
+                const formattedTime = formatTime(timeRemaining);
+                timerValue.textContent = formattedTime;
+
+                // Update visual state based on time remaining
+                if (timeRemaining <= 0) {
+                    timerElement.classList.add('expired');
+                    timerElement.classList.remove('warning');
+                    timerLabel.textContent = isExamMode ? 'Exam Ended' : 'Lab Expired';
+                } else if (timeRemaining <= WARNING_THRESHOLD) {
+                    timerElement.classList.add('warning');
+                    timerElement.classList.remove('expired');
+                } else {
+                    timerElement.classList.remove('warning', 'expired');
+                }
+            }
+
+            // Show error state
+            function showError(message) {
+                timerValue.textContent = 'Error';
+                timerValue.classList.add('timer-error');
+                timerLabel.textContent = message || 'Connection Error';
+                console.error('[ATD Timer]', message);
+            }
+
+            // Main update loop
+            async function update() {
+                try {
+                    const data = await fetchTimerData();
+
+                    // Store boottime if available
+                    if (data.boottime) {
+                        labBoottime = data.boottime;
+                    }
+
+                    // Calculate and display time remaining
+                    const timeRemaining = calculateTimeRemaining(data);
+                    updateTimer(timeRemaining);
+
+                } catch (error) {
+                    showError('Failed to fetch timer');
+
+                    // Retry after delay
+                    if (updateInterval) {
+                        clearInterval(updateInterval);
+                    }
+                    setTimeout(() => {
+                        startTimer();
+                    }, RETRY_DELAY);
+                }
+            }
+
+            // Start timer updates
+            function startTimer() {
+                // Initial update
+                update();
+
+                // Set up interval for regular updates
+                if (updateInterval) {
+                    clearInterval(updateInterval);
+                }
+                updateInterval = setInterval(update, UPDATE_INTERVAL);
+            }
+
+            // Initialize timer
+            async function init() {
+                console.log('[ATD Timer] Initializing countdown timer widget');
+
+                // Detect exam mode
+                await detectExamMode();
+
+                // Start timer updates
+                startTimer();
+
+                // Clean up on page unload
+                window.addEventListener('beforeunload', () => {
+                    if (updateInterval) {
+                        clearInterval(updateInterval);
+                    }
+                });
+            }
+
+            // Start when DOM is ready
+            if (document.readyState === 'loading') {
+                document.addEventListener('DOMContentLoaded', init);
+            } else {
+                init();
+            }
+        })();
+    </script>
+</body>
+</html>

--- a/nested-labvm/atd-docker/nginx/src/timer-widget.js
+++ b/nested-labvm/atd-docker/nginx/src/timer-widget.js
@@ -1,0 +1,409 @@
+(function() {
+    'use strict';
+
+    // Inject timer widget HTML
+    const timerHTML = `
+        <div id="atd-countdown-timer" draggable="true">
+            <div class="timer-header">
+                <div class="timer-label">Time Remaining</div>
+                <div class="drag-hint">⋮⋮</div>
+            </div>
+            <div class="timer-value">--:--:--</div>
+        </div>
+    `;
+
+    // Inject CSS - matching uilanding color scheme
+    const timerCSS = `
+        #atd-countdown-timer {
+            position: fixed;
+            top: 10px;
+            right: 10px;
+            background: linear-gradient(135deg, #04152a 0%, #071a33 100%);
+            border: 2px solid #fbb500;
+            color: white;
+            padding: 12px 18px;
+            border-radius: 8px;
+            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+            font-size: 14px;
+            font-weight: 600;
+            z-index: 999999;
+            box-shadow: 0 4px 16px rgba(251, 181, 0, 0.3);
+            min-width: 140px;
+            text-align: center;
+            cursor: move;
+            transition: box-shadow 0.3s ease;
+        }
+
+        #atd-countdown-timer:hover {
+            box-shadow: 0 6px 20px rgba(251, 181, 0, 0.5);
+        }
+
+        #atd-countdown-timer.dragging {
+            opacity: 0.8;
+            box-shadow: 0 8px 24px rgba(251, 181, 0, 0.6);
+        }
+
+        #atd-countdown-timer.exam-mode {
+            border-color: #78d82c;
+            box-shadow: 0 4px 16px rgba(120, 216, 44, 0.3);
+        }
+
+        #atd-countdown-timer.exam-mode:hover {
+            box-shadow: 0 6px 20px rgba(120, 216, 44, 0.5);
+        }
+
+        #atd-countdown-timer.warning {
+            border-color: #ff6b6b;
+            animation: pulse 2s infinite;
+        }
+
+        #atd-countdown-timer.expired {
+            background: linear-gradient(135deg, #1a0a0a 0%, #2a0505 100%);
+            border-color: #ff6b6b;
+        }
+
+        @keyframes pulse {
+            0%, 100% {
+                box-shadow: 0 4px 16px rgba(255, 107, 107, 0.3);
+            }
+            50% {
+                box-shadow: 0 6px 20px rgba(255, 107, 107, 0.6);
+            }
+        }
+
+        .timer-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 4px;
+        }
+
+        .timer-label {
+            font-size: 10px;
+            opacity: 0.9;
+            text-transform: uppercase;
+            letter-spacing: 0.5px;
+            color: #fbb500;
+        }
+
+        .drag-hint {
+            font-size: 14px;
+            opacity: 0.5;
+            color: #fbb500;
+            cursor: move;
+        }
+
+        .timer-value {
+            font-size: 22px;
+            font-weight: 700;
+            letter-spacing: 1.5px;
+            font-family: 'Courier New', monospace;
+            color: #ffffff;
+        }
+
+        .timer-error {
+            font-size: 11px;
+            opacity: 0.9;
+            color: #ff6b6b;
+        }
+    `;
+
+    const UPTIME_ENDPOINT = '/uptimeWithRuntime';
+    const UPDATE_INTERVAL = 1000; // 1 second
+    const RETRY_DELAY = 5000; // 5 seconds on error
+    const WARNING_THRESHOLD = 300; // 5 minutes in seconds
+
+    let timerElement = null;
+    let timerValue = null;
+    let timerLabel = null;
+    let updateInterval = null;
+    let isExamMode = false;
+    let examEndTime = null;
+    let labRuntime = null; // in hours
+
+    // Dragging state
+    let isDragging = false;
+    let currentX = 0;
+    let currentY = 0;
+    let initialX = 0;
+    let initialY = 0;
+    let xOffset = 0;
+    let yOffset = 0;
+
+    // Format seconds to HH:MM:SS
+    function formatTime(seconds) {
+        if (seconds < 0) return '00:00:00';
+
+        const hours = Math.floor(seconds / 3600);
+        const minutes = Math.floor((seconds % 3600) / 60);
+        const secs = Math.floor(seconds % 60);
+
+        return [
+            String(hours).padStart(2, '0'),
+            String(minutes).padStart(2, '0'),
+            String(secs).padStart(2, '0')
+        ].join(':');
+    }
+
+    // Fetch timer data from uptime endpoint
+    async function fetchTimerData() {
+        try {
+            const response = await fetch(UPTIME_ENDPOINT, {
+                method: 'GET',
+                headers: {
+                    'Accept': 'application/json'
+                },
+                cache: 'no-cache'
+            });
+
+            if (!response.ok) {
+                throw new Error(`HTTP ${response.status}`);
+            }
+
+            const data = await response.json();
+            return data;
+        } catch (error) {
+            console.error('[ATD Timer] Failed to fetch timer data:', error);
+            throw error;
+        }
+    }
+
+    // Calculate time remaining
+    function calculateTimeRemaining(data) {
+        const currentTime = Math.floor(Date.now() / 1000);
+        let timeRemaining = 0;
+
+        // Check if exam mode is active (exam_end_time > 0 means exam has started)
+        if (data.exam_end_time && data.exam_end_time > 0) {
+            // Exam mode: Use absolute end time from server
+            if (!isExamMode) {
+                // First time detecting exam mode
+                isExamMode = true;
+                timerElement.classList.add('exam-mode');
+                console.log('[ATD Timer] Exam mode detected');
+            }
+            examEndTime = data.exam_end_time;
+            timeRemaining = examEndTime - currentTime;
+        } else if (data.boottime && data.boottime > 0) {
+            // Normal lab mode: Use boottime + runtime
+            // Use runtime from data if available, otherwise use stored value or default to 12 hours
+            const runtime = data.runtime || labRuntime || 12;
+
+            // Store runtime for future use if we got it from the server
+            if (data.runtime && data.runtime !== labRuntime) {
+                labRuntime = data.runtime;
+            }
+
+            const expirationTime = data.boottime + (runtime * 60 * 60);
+            timeRemaining = expirationTime - currentTime;
+        } else {
+            // Boottime is 0 or missing - lab is still initializing
+            return null; // Return null to indicate loading state
+        }
+
+        return timeRemaining;
+    }
+
+    // Update timer display
+    function updateTimer(timeRemaining) {
+        if (!timerValue) return;
+
+        const formattedTime = formatTime(timeRemaining);
+        timerValue.textContent = formattedTime;
+        timerValue.classList.remove('timer-error');
+
+        // Update visual state based on time remaining
+        if (timeRemaining <= 0) {
+            timerElement.classList.add('expired');
+            timerElement.classList.remove('warning');
+            timerLabel.textContent = isExamMode ? 'Exam Ended' : 'Lab Expired';
+        } else if (timeRemaining <= WARNING_THRESHOLD) {
+            timerElement.classList.add('warning');
+            timerElement.classList.remove('expired');
+            timerLabel.textContent = 'Time Remaining';
+        } else {
+            timerElement.classList.remove('warning', 'expired');
+            timerLabel.textContent = 'Time Remaining';
+        }
+    }
+
+    // Show error state
+    function showError(message) {
+        if (!timerValue || !timerLabel) return;
+
+        timerValue.textContent = 'Error';
+        timerValue.classList.add('timer-error');
+        timerLabel.textContent = message || 'Connection Error';
+        console.error('[ATD Timer]', message);
+    }
+
+    // Main update loop
+    async function update() {
+        try {
+            const data = await fetchTimerData();
+
+            // Calculate and display time remaining
+            const timeRemaining = calculateTimeRemaining(data);
+
+            if (timeRemaining === null) {
+                // Lab is still initializing, show loading state
+                if (timerValue) {
+                    timerValue.textContent = 'Loading...';
+                    timerValue.classList.remove('timer-error');
+                    timerLabel.textContent = 'Initializing';
+                }
+            } else {
+                updateTimer(timeRemaining);
+            }
+
+        } catch (error) {
+            showError('Failed to fetch');
+
+            // Retry after delay
+            if (updateInterval) {
+                clearInterval(updateInterval);
+            }
+            setTimeout(() => {
+                startTimer();
+            }, RETRY_DELAY);
+        }
+    }
+
+    // Start timer updates
+    function startTimer() {
+        // Initial update
+        update();
+
+        // Set up interval for regular updates
+        if (updateInterval) {
+            clearInterval(updateInterval);
+        }
+        updateInterval = setInterval(update, UPDATE_INTERVAL);
+    }
+
+    // Dragging functionality
+    function dragStart(e) {
+        if (e.type === "touchstart") {
+            initialX = e.touches[0].clientX - xOffset;
+            initialY = e.touches[0].clientY - yOffset;
+        } else {
+            initialX = e.clientX - xOffset;
+            initialY = e.clientY - yOffset;
+        }
+
+        if (e.target === timerElement || e.target.closest('#atd-countdown-timer')) {
+            isDragging = true;
+            timerElement.classList.add('dragging');
+        }
+    }
+
+    function drag(e) {
+        if (isDragging) {
+            e.preventDefault();
+
+            if (e.type === "touchmove") {
+                currentX = e.touches[0].clientX - initialX;
+                currentY = e.touches[0].clientY - initialY;
+            } else {
+                currentX = e.clientX - initialX;
+                currentY = e.clientY - initialY;
+            }
+
+            xOffset = currentX;
+            yOffset = currentY;
+
+            setTranslate(currentX, currentY, timerElement);
+        }
+    }
+
+    function dragEnd() {
+        initialX = currentX;
+        initialY = currentY;
+        isDragging = false;
+        if (timerElement) {
+            timerElement.classList.remove('dragging');
+        }
+    }
+
+    function setTranslate(xPos, yPos, el) {
+        el.style.transform = `translate3d(${xPos}px, ${yPos}px, 0)`;
+    }
+
+    // Initialize timer
+    function init() {
+        // Only show timer in top-level window, not in iframes
+        if (window !== window.top) {
+            console.log('[ATD Timer] Skipping timer in iframe');
+            return;
+        }
+
+        // Prevent duplicate timers
+        if (document.getElementById('atd-countdown-timer')) {
+            console.log('[ATD Timer] Timer already exists, skipping initialization');
+            return;
+        }
+
+        console.log('[ATD Timer] Initializing countdown timer widget');
+
+        // Inject CSS
+        const style = document.createElement('style');
+        style.textContent = timerCSS;
+        document.head.appendChild(style);
+
+        // Inject HTML
+        const div = document.createElement('div');
+        div.innerHTML = timerHTML;
+        document.body.appendChild(div.firstElementChild);
+
+        // Get references to elements
+        timerElement = document.getElementById('atd-countdown-timer');
+        timerValue = timerElement.querySelector('.timer-value');
+        timerLabel = timerElement.querySelector('.timer-label');
+
+        // Load saved position from localStorage
+        const savedPos = localStorage.getItem('atd-timer-position');
+        if (savedPos) {
+            try {
+                const pos = JSON.parse(savedPos);
+                xOffset = pos.x || 0;
+                yOffset = pos.y || 0;
+                setTranslate(xOffset, yOffset, timerElement);
+            } catch (e) {
+                console.error('[ATD Timer] Failed to load saved position:', e);
+            }
+        }
+
+        // Add drag event listeners
+        timerElement.addEventListener('mousedown', dragStart, false);
+        document.addEventListener('mousemove', drag, false);
+        document.addEventListener('mouseup', dragEnd, false);
+
+        // Touch events for mobile
+        timerElement.addEventListener('touchstart', dragStart, false);
+        document.addEventListener('touchmove', drag, false);
+        document.addEventListener('touchend', dragEnd, false);
+
+        // Start timer updates
+        startTimer();
+
+        // Clean up on page unload
+        window.addEventListener('beforeunload', () => {
+            // Save position
+            localStorage.setItem('atd-timer-position', JSON.stringify({
+                x: xOffset,
+                y: yOffset
+            }));
+
+            if (updateInterval) {
+                clearInterval(updateInterval);
+            }
+        });
+    }
+
+    // Start when DOM is ready
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init);
+    } else {
+        init();
+    }
+})();

--- a/nested-labvm/atd-docker/uilanding/src/html/terminal.html
+++ b/nested-labvm/atd-docker/uilanding/src/html/terminal.html
@@ -1744,6 +1744,9 @@
       });
     });
   </script>
+
+  <!-- Timer Widget -->
+  <script src="/timer-widget.js"></script>
 </body>
 
 </html>

--- a/nested-labvm/atd-docker/uilanding/src/uilanding.py
+++ b/nested-labvm/atd-docker/uilanding/src/uilanding.py
@@ -973,6 +973,53 @@ class BaseUrlHandler(tornado.web.RequestHandler):
             self.set_status(500)
             self.write({"error": str(e)})
 
+class UptimeWithRuntimeHandler(tornado.web.RequestHandler):
+    def get(self):
+        """
+        Handler to provide uptime data with runtime information for timer widget
+        """
+        try:
+            self.set_header("Access-Control-Allow-Origin", "*")
+            self.set_header("Content-Type", "application/json")
+
+            # Get uptime data directly from atd-uptime service
+            try:
+                response = requests.get("http://atd-uptime:50010/uptime", timeout=1)
+                instance_data = response.json()
+
+                # Add runtime from topology metadata
+                if instance_data.get('status') == 'init' and TOPO_DATA and 'labels' in TOPO_DATA and 'runtime' in TOPO_DATA['labels']:
+                    instance_data['runtime'] = int(TOPO_DATA['labels']['runtime'])
+                else:
+                    instance_data['runtime'] = 12
+
+                # Add exam time information if available
+                instance_data['exam_end_time'] = EXAM_END_TIME
+                instance_data['exam_start_time'] = EXAM_START_TIME
+
+                self.write(json.dumps(instance_data))
+            except:
+                # If uptime service is not ready, return default values
+                self.write(json.dumps({
+                    'boottime': 0,
+                    'uptime': 0,
+                    'runtime': 12,
+                    'status': 'init',
+                    'exam_end_time': EXAM_END_TIME,
+                    'exam_start_time': EXAM_START_TIME
+                }))
+        except Exception as e:
+            self.set_status(500)
+            self.write(json.dumps({
+                "error": str(e),
+                "boottime": 0,
+                "uptime": 0,
+                "runtime": 12,
+                "status": "error",
+                "exam_end_time": 0,
+                "exam_start_time": 0
+            }))
+
 class GetAccessInfoHandler(tornado.web.RequestHandler):
     def validate_field(self, customer_details, field_name, default_value, validated_details, defaulted_fields):
         """
@@ -2988,9 +3035,10 @@ if __name__ == "__main__":
         (r'/getClientId', GetClientIdHandler),
         (r'/getExamInstructions', GetExamInstructionsHandler),
         (r'/getUserSessionId', GetUserSessionIdHandler),
-        (r'/beginExam', BeginExamHandler),  
+        (r'/beginExam', BeginExamHandler),
         (r'/endExam', EndExamHandler),
         (r'/baseUrl', BaseUrlHandler),
+        (r'/uptimeWithRuntime', UptimeWithRuntimeHandler),
         (r'/terminal', TerminalPageHandler),
         (r'/td-api/devices', DevicesAPIHandler),
         (r'/td-api/device-types', DeviceTypesAPIHandler),


### PR DESCRIPTION
This pull request introduces a timer widget that displays the remaining lab or exam time to users across the UI by injecting a JavaScript countdown timer into proxied HTML responses and providing the necessary backend and NGINX configuration to support it. The main changes span frontend, backend, and infrastructure to enable automatic and robust timer display for lab sessions and exams.

**Key changes include:**

**Timer Widget Injection and Delivery:**
- Configured NGINX (`atd.conf`, `Dockerfile`) to inject a `<script src="/timer-widget.js"></script>` tag before the `</body>` of proxied HTML responses, ensuring the timer widget is loaded on relevant pages. This is done using `sub_filter`, and the static JS file is made available at `/timer-widget.js` with appropriate headers to prevent caching. [[1]](diffhunk://#diff-525f193af994bee2dd99e7af877ea7ad2f4c3060d8298d7c08dac7f764685884R48-R53) [[2]](diffhunk://#diff-525f193af994bee2dd99e7af877ea7ad2f4c3060d8298d7c08dac7f764685884R68-R73) [[3]](diffhunk://#diff-525f193af994bee2dd99e7af877ea7ad2f4c3060d8298d7c08dac7f764685884R89-R93) [[4]](diffhunk://#diff-525f193af994bee2dd99e7af877ea7ad2f4c3060d8298d7c08dac7f764685884R106-R126) [[5]](diffhunk://#diff-525f193af994bee2dd99e7af877ea7ad2f4c3060d8298d7c08dac7f764685884R137-R142) [[6]](diffhunk://#diff-525f193af994bee2dd99e7af877ea7ad2f4c3060d8298d7c08dac7f764685884R153-R158) [[7]](diffhunk://#diff-525f193af994bee2dd99e7af877ea7ad2f4c3060d8298d7c08dac7f764685884R173-R178) [[8]](diffhunk://#diff-525f193af994bee2dd99e7af877ea7ad2f4c3060d8298d7c08dac7f764685884R200-R205) [[9]](diffhunk://#diff-7ed36c46243ea4640f99533db7d3fe42844b2280588b0e1e4fe05c92c4d13263R5-R6)

**Frontend Timer Widget Implementation:**
- Added a new `timer-widget.js` (and an accompanying HTML for development) implementing a visually styled, fixed-position countdown timer. The widget fetches lab uptime and runtime info from the backend, displays time remaining, handles exam mode, and visually warns as time runs out or expires.

**Backend API Support:**
- Added a new Tornado handler `UptimeWithRuntimeHandler` and registered it at `/uptimeWithRuntime`, which aggregates uptime, runtime, and exam timing information from the topology metadata and the uptime service, providing robust data for the timer widget. [[1]](diffhunk://#diff-146c55e95bc1cdf66b231e2984311d32a16d749fa2d259fd740f6bace0056e1bR976-R1022) [[2]](diffhunk://#diff-146c55e95bc1cdf66b231e2984311d32a16d749fa2d259fd740f6bace0056e1bR3041)

**UI Integration:**
- Ensured the timer widget is also explicitly loaded in the terminal UI HTML for direct access.

These changes collectively ensure that users are always aware of their remaining lab or exam time, improving the user experience and reducing the risk of unexpected session expiry.

**References:**  
[[1]](diffhunk://#diff-525f193af994bee2dd99e7af877ea7ad2f4c3060d8298d7c08dac7f764685884R48-R53) [[2]](diffhunk://#diff-525f193af994bee2dd99e7af877ea7ad2f4c3060d8298d7c08dac7f764685884R68-R73) [[3]](diffhunk://#diff-525f193af994bee2dd99e7af877ea7ad2f4c3060d8298d7c08dac7f764685884R89-R93) [[4]](diffhunk://#diff-525f193af994bee2dd99e7af877ea7ad2f4c3060d8298d7c08dac7f764685884R106-R126) [[5]](diffhunk://#diff-525f193af994bee2dd99e7af877ea7ad2f4c3060d8298d7c08dac7f764685884R137-R142) [[6]](diffhunk://#diff-525f193af994bee2dd99e7af877ea7ad2f4c3060d8298d7c08dac7f764685884R153-R158) [[7]](diffhunk://#diff-525f193af994bee2dd99e7af877ea7ad2f4c3060d8298d7c08dac7f764685884R173-R178) [[8]](diffhunk://#diff-525f193af994bee2dd99e7af877ea7ad2f4c3060d8298d7c08dac7f764685884R200-R205) [[9]](diffhunk://#diff-7ed36c46243ea4640f99533db7d3fe42844b2280588b0e1e4fe05c92c4d13263R5-R6) [[10]](diffhunk://#diff-beedc280edab9d38858cf71f8ddcac727872f1ae3baa8cc402de39aa34bddf7bR1-R264) [[11]](diffhunk://#diff-146c55e95bc1cdf66b231e2984311d32a16d749fa2d259fd740f6bace0056e1bR976-R1022) [[12]](diffhunk://#diff-146c55e95bc1cdf66b231e2984311d32a16d749fa2d259fd740f6bace0056e1bR3041) [[13]](diffhunk://#diff-2ca4db95a2f06e9ba7f52c0cdceca54932eea156fae227c22ac267c392376438R1747-R1749)