### PR TITLE
Improvement/fix lab menu distance

### DIFF
--- a/nested-labvm/atd-docker/docker-compose.yml
+++ b/nested-labvm/atd-docker/docker-compose.yml
@@ -85,7 +85,7 @@ services:
       - /opt/ceos:/opt/ceos:rw
   uilanding:
     container_name: atd-uilanding
-    image: us.gcr.io/atd-testdrivetraining-dev/atddocker_uilanding:1.0.29-honorlock
+    image: us.gcr.io/atd-testdrivetraining-dev/atddocker_uilanding:1.0.30-honorlock
     restart: always
     environment:
       - PYTHONUNBUFFERED=1
@@ -162,7 +162,7 @@ services:
       - "1813:1813/udp"
   nginx:
     container_name: atd-nginx
-    image: us.gcr.io/atd-testdrivetraining-dev/atddocker_nginx:1.0.14
+    image: us.gcr.io/atd-testdrivetraining-dev/atddocker_nginx:1.0.15
     restart: always
     depends_on:
       - uilanding

--- a/nested-labvm/atd-docker/nginx/src/atd.conf
+++ b/nested-labvm/atd-docker/nginx/src/atd.conf
@@ -100,6 +100,44 @@ server {
         proxy_set_header  X-Real-IP $remote_addr;
         proxy_set_header  X-Forwarded-For $remote_addr;
     }
+    # Feature flags API - returns enabled features for this lab
+    location /feature-flags {
+        proxy_pass http://atd-configservice:50011/features;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $remote_addr;
+    }
+    location /feature-flags/ {
+        proxy_pass http://atd-configservice:50011/features/;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $remote_addr;
+    }
+    # Announcements API - returns active announcements for this lab
+    location /announcements {
+        proxy_pass http://atd-configservice:50011/announcements;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $remote_addr;
+    }
+    location /announcements/ {
+        proxy_pass http://atd-configservice:50011/announcements/;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $remote_addr;
+    }
+    # Combined config API - returns both features and announcements
+    location /config-api {
+        proxy_pass http://atd-configservice:50011/config;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $remote_addr;
+    }
     location /uptimeWithRuntime {
         access_log off;
         proxy_pass http://atd-uilanding/uptimeWithRuntime;
@@ -123,6 +161,11 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+        
+        # Inject unified header into Jenkins HTML
+        sub_filter '</head>' '<script src="/unified-header.js"></script></head>';
+        sub_filter_once on;
+        proxy_set_header Accept-Encoding "";
     }
     # === Static Assets for Unified Header ===
     # Note: /js/ is NOT mapped here - it's served by uilanding for app JS files

--- a/nested-labvm/atd-docker/nginx/src/js/unified-header.js
+++ b/nested-labvm/atd-docker/nginx/src/js/unified-header.js
@@ -27,6 +27,10 @@ function init() {
         return;
     }
     injectCSS();
+    // Detect CVP pages
+    if (document.getElementById("main")) {
+        document.body.classList.add("has-main");
+    }
     injectHTML();
     initializeHeader();
     console.log('[UnifiedHeader] Injection complete');
@@ -54,6 +58,70 @@ function injectCSS() {
         body {
             margin-top: 44px !important;
         }
+
+        /* CVP spacing fix */
+        body.has-main {
+            margin-top: 0 !important;
+        }
+
+        #main {
+            padding-top: 44px !important;
+        }
+
+        /* Collapse feature */
+        .header-collapse-btn {
+            padding: 4px 8px;
+            height: 28px;
+            background: transparent;
+            border: 1px solid #fbb500;
+            color: #fbb500;
+            font-size: 18px;
+            cursor: pointer;
+        }
+
+        .header-expand-btn {
+            position: fixed;
+            top: 0;
+            right: 16px;
+            background: #071c35;
+            border: 1px solid #fbb500;
+            border-top: none;
+            border-radius: 0 0 4px 4px;
+            color: #fbb500;
+            padding: 4px 12px;
+            font-size: 11px;
+            cursor: pointer;
+            z-index: 100001;
+            opacity: 0;
+            pointer-events: none;
+            transition: all 0.3s ease;
+        }
+
+        body.header-collapsed .unified-header {
+            transform: translateY(-44px);
+            transition: transform 0.3s ease;
+        }
+
+        body.header-collapsed .header-expand-btn {
+            transform: translateY(44px);
+            opacity: 1;
+            pointer-events: auto;
+        }
+
+        body.header-collapsed.has-main {
+            margin-top: 0 !important;
+        }
+
+        body.header-collapsed #main {
+            padding-top: 0 !important;
+        }
+        /* CVP-specific: Ensure #main div does not overlap header */
+        #main {
+            padding-top: 44px !important;
+            margin-top: 0 !important;
+            box-sizing: border-box;
+        }
+
 
         .header-left {
             display: flex;
@@ -332,8 +400,65 @@ function injectCSS() {
             }
 
             body {
-                margin-top: auto !important;
+                margin-top: 44px !important;
             }
+
+        /* CVP spacing fix */
+        body.has-main {
+            margin-top: 0 !important;
+        }
+
+        #main {
+            padding-top: 44px !important;
+        }
+
+        /* Collapse feature */
+        .header-collapse-btn {
+            padding: 4px 8px;
+            height: 28px;
+            background: transparent;
+            border: 1px solid #fbb500;
+            color: #fbb500;
+            font-size: 18px;
+            cursor: pointer;
+        }
+
+        .header-expand-btn {
+            position: fixed;
+            top: 0;
+            right: 16px;
+            background: #071c35;
+            border: 1px solid #fbb500;
+            border-top: none;
+            border-radius: 0 0 4px 4px;
+            color: #fbb500;
+            padding: 4px 12px;
+            font-size: 11px;
+            cursor: pointer;
+            z-index: 100001;
+            opacity: 0;
+            pointer-events: none;
+            transition: all 0.3s ease;
+        }
+
+        body.header-collapsed .unified-header {
+            transform: translateY(-44px);
+            transition: transform 0.3s ease;
+        }
+
+        body.header-collapsed .header-expand-btn {
+            transform: translateY(44px);
+            opacity: 1;
+            pointer-events: auto;
+        }
+
+        body.header-collapsed.has-main {
+            margin-top: 0 !important;
+        }
+
+        body.header-collapsed #main {
+            padding-top: 0 !important;
+        }
 
             .header-left,
             .header-center,
@@ -355,6 +480,7 @@ function injectCSS() {
 
 function injectHTML() {
     const html = `
+        <button class="header-expand-btn" id="headerExpandBtn">▼ Show</button>
         <div class="unified-header">
             <div class="header-left">
                 <a href="/" class="arista-logo">
@@ -382,6 +508,7 @@ function injectHTML() {
 
             <div class="header-right">
                 <button class="labguides-toggle" id="labguidesToggle">Lab Guides</button>
+                <button class="header-collapse-btn" id="headerCollapseBtn" title="Hide Header">▲</button>
             </div>
         </div>
 
@@ -404,6 +531,8 @@ function initializeHeader() {
     loadCredentials();
     initializeTimer();
     initializeLabGuides();
+    initializeCollapse();
+    applyCollapsedState();
 
     // Hide Lab Guides button on labguides page
     if (window.location.pathname.startsWith('/labguides')) {
@@ -591,4 +720,27 @@ function initializeLabGuides() {
             }
         }
     });
+}
+
+function initializeCollapse() {
+    const collapseBtn = document.getElementById("headerCollapseBtn");
+    const expandBtn = document.getElementById("headerExpandBtn");
+    if (collapseBtn) {
+        collapseBtn.onclick = () => {
+            document.body.classList.add("header-collapsed");
+            localStorage.setItem("headerCollapsed", "true");
+        };
+    }
+    if (expandBtn) {
+        expandBtn.onclick = () => {
+            document.body.classList.remove("header-collapsed");
+            localStorage.setItem("headerCollapsed", "false");
+        };
+    }
+}
+
+function applyCollapsedState() {
+    if (localStorage.getItem("headerCollapsed") === "true") {
+        document.body.classList.add("header-collapsed");
+    }
 }

--- a/nested-labvm/atd-docker/uilanding/src/uilanding.py
+++ b/nested-labvm/atd-docker/uilanding/src/uilanding.py
@@ -252,12 +252,16 @@ class topoRequestHandler(BaseHandler):
                 disable_links = host_yaml['disabled_links']
             else:
                 disable_links = []
-            menu={} 
+            menu={}
             if NOMENUOPTIONFILE:
                 disable_links.append('lab_menu')
             else:
                 for lab in MENU_ITEMS['lab_list']:
                     menu[lab] = MENU_ITEMS['lab_list'][lab]['description']
+
+            # Disable lab_menu for Exam type labs
+            if lab_type == "Exam" and 'lab_menu' not in disable_links:
+                disable_links.append('lab_menu')
             if 'labguides' in host_yaml:
                 if host_yaml['labguides'] == 'self':
                     labguides = '/labguides/index.html'


### PR DESCRIPTION
## Summary
- Fix CVP spacing issue where unified header caused excessive white space between header and CVP content
- Add collapsible header feature allowing users to hide/show the unified header
- Extend unified header injection to Jenkins pages
- Add config service API routes for feature flags and announcements

## Changes

### nginx/src/js/unified-header.js
- **CVP Spacing Fix**: Detect pages with `#main` div (CVP React apps) and adjust spacing to prevent double margins
  - Remove body margin on CVP pages, use only `#main` padding
  - Prevents 88px spacing gap on CVP pages like `/cv` and `/cv/devices`

- **Collapsible Header**: Add collapse/expand functionality
  - Collapse button (▲) in header right section
  - Expand button (▼ Show) appears when header is collapsed
  - State persists across page loads via localStorage
  - Smooth CSS transitions using transforms
  - Works on all pages including CVP, Jenkins, lab guides, etc.

- **New Functions**:
  - `initializeCollapse()` - Sets up collapse/expand button click handlers
  - `applyCollapsedState()` - Restores collapsed state from localStorage on page load

### nginx/src/atd.conf
- **Jenkins Integration**: Inject unified header into Jenkins HTML pages
  - Uses `sub_filter` directive to inject script before `</head>` tag
  - Disables Accept-Encoding to allow sub_filter to work

- **Config Service Routes**: Add API endpoints for feature flags and announcements
  - `/feature-flags` → `atd-configservice:50011/features`
  - `/announcements` → `atd-configservice:50011/announcements`
  - `/config-api` → `atd-configservice:50011/config`