### PR TITLE
Improve logging: reduce noise, add labguide tracking, add session met…

### DIFF
--- a/nested-labvm/atd-docker/nginx/src/js/unified-header.js
+++ b/nested-labvm/atd-docker/nginx/src/js/unified-header.js
@@ -21,6 +21,65 @@ if (window.__unifiedHeaderInjected) {
     }
 }
 
+// cloudLog: fire-and-forget log to Cloud Logging via uilanding endpoint
+if (typeof window.cloudLog === 'undefined') {
+    window.cloudLog = function(level, message, extra) {
+        try {
+            var payload = { level: level || 'info', message: message || '' };
+            if (extra) { for (var k in extra) { if (extra.hasOwnProperty(k)) payload[k] = extra[k]; } }
+            if (navigator.sendBeacon) { navigator.sendBeacon('/td-api/client-log', JSON.stringify(payload)); }
+        } catch(e) {}
+    };
+}
+
+// Track labguide page views: /labguides/CVP-Navigating-L3-2023.2-RST.html
+if (!window.__labguideTracked) {
+    window.__labguideTracked = true;
+    (function() {
+        var path = window.location.pathname;
+        if (path.indexOf('/labguides') === 0) {
+            var page = path.replace('/labguides/', '').replace(/\.html$/, '') || 'index';
+            if (path === '/labguides' || path === '/labguides/') { page = 'index'; }
+
+            // Skip Sphinx utility pages
+            if (['genindex', 'search', 'py-modindex'].indexOf(page) !== -1) { return; }
+
+            // Capture section from hash fragment (e.g., #lab-topology)
+            var section = window.location.hash ? window.location.hash.replace('#', '') : '';
+
+            // Detect context: standalone vs iframe (unified header panel)
+            var isIframe = (window.self !== window.top);
+            var context = 'standalone';
+            var parentPage = '';
+            if (isIframe) {
+                try {
+                    var parentPath = window.top.location.pathname;
+                    if (parentPath.indexOf('/cv') === 0) { context = 'cvp'; }
+                    else if (parentPath.indexOf('/terminal') === 0) { context = 'terminal'; }
+                    else if (parentPath.indexOf('/coder') === 0) { context = 'coder'; }
+                    else if (parentPath.indexOf('/firefox') === 0) { context = 'browser'; }
+                    else if (parentPath.indexOf('/console') === 0) { context = 'console'; }
+                    else if (parentPath.indexOf('/topology-converter') === 0) { context = 'topology-converter'; }
+                    else if (parentPath.indexOf('/host') === 0) { context = 'host-vm'; }
+                    else if (parentPath === '/' || parentPath.indexOf('/topology') === 0) { context = 'uilanding'; }
+                    else { context = 'iframe'; }
+                    parentPage = parentPath;
+                } catch(e) { context = 'iframe'; }
+            }
+
+            var logData = {
+                source: 'unified-header',
+                action: 'labguide_page_viewed',
+                page: page,
+                context: context,
+                parent_page: parentPage
+            };
+            if (section) { logData.section = section; }
+            window.cloudLog('info', 'Lab guide viewed: ' + page, logData);
+        }
+    })();
+}
+
 function init() {
     if (document.querySelector('.unified-header')) {
         console.log('[UnifiedHeader] Header appeared during load, skipping');

--- a/nested-labvm/atd-docker/uilanding/src/handlers/pages.py
+++ b/nested-labvm/atd-docker/uilanding/src/handlers/pages.py
@@ -443,7 +443,7 @@ class ClientLogHandler(tornado.web.RequestHandler):
             kwargs = {'event': 'client', 'source': source}
             if action:
                 kwargs['action'] = action
-            for key in ('device', 'topology', 'session_id', 'client_id'):
+            for key in ('device', 'topology', 'session_id', 'client_id', 'page', 'context', 'parent_page', 'section'):
                 if key in data:
                     kwargs[key] = str(data[key])[:100]
             safe_log(level, message, **kwargs)

--- a/nested-labvm/atd-docker/uilanding/src/handlers/session_logger.py
+++ b/nested-labvm/atd-docker/uilanding/src/handlers/session_logger.py
@@ -1,0 +1,34 @@
+"""
+Log lab session metadata to Cloud Logging at startup.
+
+Called once when uilanding starts. Captures lab identity, user details,
+course info, and topology config for analytics and troubleshooting.
+"""
+
+from utils import safe_log
+
+
+def log_lab_session(host_yaml):
+    """Log lab session details from ACCESS_INFO.yaml."""
+    try:
+        cust = host_yaml.get('customer_details') or {}
+        login = (host_yaml.get('login_info') or {}).get('jump_host') or {}
+        modules = host_yaml.get('labguides_modules') or []
+
+        safe_log('info', 'Lab session started',
+            event='session',
+            action='lab_session_start',
+            lab_name=host_yaml.get('name') or '',
+            topology=host_yaml.get('topology') or '',
+            course_name=cust.get('course_name') or '',
+            lab_type=cust.get('lab_type') or 'LAB',
+            user_email=cust.get('exam_taker_email') or '',
+            user_name=cust.get('exam_taker_full_name') or '',
+            labguides_modules=','.join(str(m) for m in modules) if isinstance(modules, list) else str(modules),
+            login_user=login.get('user') or '',
+            eos_type=host_yaml.get('eos_type') or 'veos',
+            zone=host_yaml.get('zone') or '',
+        )
+    except Exception as e:
+        safe_log('warning', f'Failed to log lab session metadata: {e}',
+            event='session', action='lab_session_start_failed')

--- a/nested-labvm/atd-docker/uilanding/src/handlers/topology_api.py
+++ b/nested-labvm/atd-docker/uilanding/src/handlers/topology_api.py
@@ -1436,8 +1436,7 @@ class DeviceStatusAPIHandler(BaseHandler):
         if not device_ip:
             device_ip = get_device_ip_from_sources(device_name)
 
-        safe_log('info', f'Device status check: {device_name} -> {device_ip}',
-                 event='api', handler='DeviceStatusAPIHandler', device=str(device_name))
+        # Removed per-device status check log (100 logs/device/session = ~2400 logs noise)
         if not device_ip:
             return {
                 'device': device_name,
@@ -1616,8 +1615,7 @@ class DeviceStatusAPIHandler(BaseHandler):
         nodes = get_all_devices()
         statuses = {}
 
-        safe_log('info', f'Found {len(nodes)} devices from all sources',
-                 event='api', handler='DeviceStatusAPIHandler')
+        # Removed 'Found N devices' log (fires every poll cycle, ~141/session)
 
         with ThreadPoolExecutor(max_workers=10) as executor:
             futures = {

--- a/nested-labvm/atd-docker/uilanding/src/handlers/websocket.py
+++ b/nested-labvm/atd-docker/uilanding/src/handlers/websocket.py
@@ -427,15 +427,19 @@ class topoDataHandler(tornado.websocket.WebSocketHandler):
 
         elif event == 'grpc_check':
             grpc_status = data.get('status', 'unknown')
-            log_level = 'info' if grpc_status == 'ok' else 'warning'
-            safe_log(log_level, 'Client gRPC check: ' + grpc_status,
-                event='connectivity', action='grpc_check',
-                source='client',
-                session_id=session_id,
-                client_id=str(self.session.get('client_id', '')),
-                client_ip=str(self.session['client_ip']),
-                status=str(grpc_status),
-                detail=str(data.get('detail', ''))[:200])
+            # Only log on state transitions (ok→error or error→ok), not every check
+            prev_grpc = getattr(self, '_last_grpc_status', None)
+            if grpc_status != prev_grpc:
+                self._last_grpc_status = grpc_status
+                log_level = 'info' if grpc_status == 'ok' else 'warning'
+                safe_log(log_level, 'Client gRPC check: ' + grpc_status,
+                    event='connectivity', action='grpc_check',
+                    source='client',
+                    session_id=session_id,
+                    client_id=str(self.session.get('client_id', '')),
+                    client_ip=str(self.session['client_ip']),
+                    status=str(grpc_status),
+                    detail=str(data.get('detail', ''))[:200])
 
         elif event == 'state_change':
             safe_log('info', 'Client connectivity state change',

--- a/nested-labvm/atd-docker/uilanding/src/html/js/atd-ws.js
+++ b/nested-labvm/atd-docker/uilanding/src/html/js/atd-ws.js
@@ -154,7 +154,11 @@ function createWS(SOCK_URL) {
         // Ping messages don't carry CVP data, so skip them to avoid resetting state
         if (reg_data['cvp'] && reg_data['cvp']['status']) {
             if (reg_data['cvp']['status'] != 'UP') {
-                cloudLog('warning', 'CVP status: ' + reg_data['cvp']['status'], { source: 'atd-ws', action: 'cvp_status_down' });
+                // Only log on state transition (not every WS message during CVP startup)
+                if (window._lastCvpStatus !== reg_data['cvp']['status']) {
+                    window._lastCvpStatus = reg_data['cvp']['status'];
+                    cloudLog('warning', 'CVP status: ' + reg_data['cvp']['status'], { source: 'atd-ws', action: 'cvp_status_down' });
+                }
 
                 // Update sidebar: show struck-through CVP, hide active CVP
                 if (elements.cvpLoading) elements.cvpLoading.style.display = "block";
@@ -194,6 +198,11 @@ function createWS(SOCK_URL) {
                     }
                 }
             } else {
+                // Log CVP UP transition (only once, not every message)
+                if (window._lastCvpStatus && window._lastCvpStatus !== 'UP') {
+                    cloudLog('info', 'CVP status: UP', { source: 'atd-ws', action: 'cvp_status_up' });
+                }
+                window._lastCvpStatus = 'UP';
                 // CVP is UP — update sidebar: hide struck-through, show active
                 if (elements.cvpLoading) elements.cvpLoading.style.display = "none";
                 if (elements.cvpLoaded) elements.cvpLoaded.style.display = "block";

--- a/nested-labvm/atd-docker/uilanding/src/html/js/connectivity-monitor.js
+++ b/nested-labvm/atd-docker/uilanding/src/html/js/connectivity-monitor.js
@@ -704,7 +704,7 @@
                 error: grpcConnectionStatus.errorMessage,
                 failureCount: grpcConnectionStatus.failureCount
             });
-            cloudLog('error', 'gRPC connectivity test failed: ' + grpcConnectionStatus.errorMessage, { source: 'connectivity-monitor', action: 'grpc_test_error' });
+            cloudLog('warning', 'gRPC connectivity test failed: ' + grpcConnectionStatus.errorMessage, { source: 'connectivity-monitor', action: 'grpc_test_error' });
             trackEvent('grpc_fail', { reason: grpcConnectionStatus.errorMessage, failures: grpcConnectionStatus.failureCount });
             sendGRPCCheckResult('error', { reason: grpcConnectionStatus.errorMessage });
             updateStatusUI();

--- a/nested-labvm/atd-docker/uilanding/src/uilanding.py
+++ b/nested-labvm/atd-docker/uilanding/src/uilanding.py
@@ -225,9 +225,11 @@ def _get_cvp_token():
             _cvp_grpc_token_expires = now + 1200  # 20 minutes
             return token
     except Exception as e:
-        safe_log('error', 'Failed to get CVP token for internal gRPC check',
-            event='connectivity', action='internal_grpc_token_error',
-            error=str(e))
+        # Only log token failures on state transition (not every check during CVP startup)
+        if _grpc_state.get('status') != 'skipped':
+            safe_log('warning', 'Failed to get CVP token for internal gRPC check',
+                event='connectivity', action='internal_grpc_token_error',
+                error=str(e))
     return None
 
 def check_cvp_grpc_internal():
@@ -238,11 +240,13 @@ def check_cvp_grpc_internal():
     """
     token = _get_cvp_token()
     if not token:
+        prev_status = _grpc_state.get('status')
         _grpc_state['status'] = 'skipped'
         _grpc_state['last_check'] = time.time()
-        safe_log('warning', 'Internal gRPC check skipped - no token',
-            event='connectivity', action='grpc_check', source='internal',
-            status='skipped', reason='no_token')
+        if prev_status != 'skipped':
+            safe_log('warning', 'Internal gRPC check skipped - no token',
+                event='connectivity', action='grpc_check', source='internal',
+                status='skipped', reason='no_token')
         return
 
     # Same 5-byte gRPC-Web frame as frontend: flag(0x00) + length(0x00000000)
@@ -270,18 +274,21 @@ def check_cvp_grpc_internal():
 
         if status_code == 200 or grpc_status is not None:
             # Check grpc-status if present
+            prev_status = _grpc_state.get('status')
             if grpc_status is not None and int(grpc_status) == 14:
                 _grpc_state['status'] = 'unavailable'
-                safe_log('warning', 'Internal gRPC check: CVP unavailable',
-                    event='connectivity', action='grpc_check', source='internal',
-                    status='unavailable', http_status=str(status_code),
-                    grpc_status=str(grpc_status))
+                if prev_status != 'unavailable':
+                    safe_log('warning', 'Internal gRPC check: CVP unavailable',
+                        event='connectivity', action='grpc_check', source='internal',
+                        status='unavailable', http_status=str(status_code),
+                        grpc_status=str(grpc_status))
             else:
                 _grpc_state['status'] = 'ok'
-                safe_log('info', 'Internal gRPC check passed',
-                    event='connectivity', action='grpc_check', source='internal',
-                    status='ok', http_status=str(status_code),
-                    grpc_status=str(grpc_status) if grpc_status else '')
+                if prev_status != 'ok':
+                    safe_log('info', 'Internal gRPC check passed',
+                        event='connectivity', action='grpc_check', source='internal',
+                        status='ok', http_status=str(status_code),
+                        grpc_status=str(grpc_status) if grpc_status else '')
         elif status_code in (401, 403, 405):
             # Token may be stale, clear it
             global _cvp_grpc_token
@@ -507,6 +514,10 @@ if __name__ == "__main__":
 
     print('*** UILanding Multi-App Server Started ***')
     print('  ui-frontend: 8080 | api: 8081 | websocket: 8082 | exam: 8083 | proxy: 8084')
+
+    # Log lab session metadata once at startup
+    from handlers.session_logger import log_lab_session
+    log_lab_session(host_yaml)
 
     try:
         TOPO_DATA = getEventStatus(NAME, ZONE, FUNC_STATE, SCHEMA)


### PR DESCRIPTION
…adata

Noise reduction (~94% fewer logs per session):
- Remove per-device status check logs (2400+/session)
- Remove 'Found N devices' poll cycle log
- Internal/client gRPC checks: log only state transitions
- CVP token error: downgrade to warning, suppress repeats
- Client gRPC test error: downgrade to warning (client firewall)
- CVP status down: log only transitions in atd-ws.js
- Add cvp_status_up event for CVP ready transition

Labguide page tracking (unified-header.js):
- Track every labguide page view via cloudLog
- Detect context: standalone, cvp, terminal, coder, browser, etc.
- Capture parent page path for iframe context
- Capture hash fragment as section label
- Filter Sphinx utility pages (genindex, search)
- Guard against double-fire from sub_filter_once off

Session metadata logging (session_logger.py):
- Log lab session details at uilanding startup
- Captures: lab_name, topology, course_name, lab_type, user_email, user_name, labguides_modules, login_user, eos_type, zone
- Handles missing customer_details gracefully

ClientLogHandler (pages.py):
- Extract page, context, parent_page, section labels from client logs