### PR TITLE
Prevent background polling from blocking idle detection

### DIFF
--- a/nested-labvm/atd-docker/nginx/src/atd.conf
+++ b/nested-labvm/atd-docker/nginx/src/atd.conf
@@ -144,7 +144,9 @@ server {
         proxy_set_header X-Forwarded-For $remote_addr;
     }
     # Announcements API - returns active announcements for this lab
+    # access_log off to prevent periodic polling from interfering with idle detection
     location /announcements {
+        access_log off;
         proxy_pass http://atd-configservice:50011/announcements;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
@@ -152,6 +154,7 @@ server {
         proxy_set_header X-Forwarded-For $remote_addr;
     }
     location /announcements/ {
+        access_log off;
         proxy_pass http://atd-configservice:50011/announcements/;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
@@ -449,6 +452,19 @@ server {
         sub_filter '</body>' '<script src="/unified-header.js"></script></body>';
         sub_filter_once off;
         proxy_set_header Accept-Encoding "";
+    }
+    # gRPC connectivity health check - excluded from access logging
+    # to prevent idle detection interference (atdMonitor reads last nginx log entry)
+    location = /td-api/grpc-health {
+        access_log off;
+        proxy_pass https://192.168.0.5/arista.studio.v1.StudioService/GetAll;
+        proxy_ssl_verify off;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $remote_addr;
+        proxy_read_timeout 5;
+        proxy_send_timeout 5;
     }
     location ~ ^/(grpc-web/arista\..*|arista\..*) {
         grpc_pass grpcs://192.168.0.5:443;

--- a/nested-labvm/atd-docker/uilanding/src/html/js/connectivity-monitor.js
+++ b/nested-labvm/atd-docker/uilanding/src/html/js/connectivity-monitor.js
@@ -597,7 +597,7 @@
             return;
         }
 
-        var grpcEndpoint = '/arista.studio.v1.StudioService/GetAll';
+        var grpcEndpoint = '/td-api/grpc-health';
         var timeout = CONNECTIVITY_CONFIG.grpc.timeout;
 
         if (window.ConnectivityDebug) {

--- a/nested-labvm/atd-docker/uilanding/src/html/js/topology/topology-manager.js
+++ b/nested-labvm/atd-docker/uilanding/src/html/js/topology/topology-manager.js
@@ -235,13 +235,14 @@ export class TopologyManager {
                 }
             }
 
-            // Initialize OrphanedSlotsMonitor for tracking orphaned interface slots (KVM labs only)
-            // This monitors for interface slots preserved from deleted devices
-            if (this.topologyData.metadata?.eos_type === 'veos') {
-                this.orphanedSlotsMonitor = new OrphanedSlotsMonitor(this);
-                this.orphanedSlotsMonitor.init();
-                console.log('[TopologyManager] OrphanedSlotsMonitor initialized');
-            }
+            // OrphanedSlotsMonitor disabled - slot preservation is off by default
+            // (nodebuilder ENABLE_SLOT_PRESERVATION=false). Re-enable here if
+            // slot preservation is turned back on in the future.
+            // if (this.topologyData.metadata?.eos_type === 'veos') {
+            //     this.orphanedSlotsMonitor = new OrphanedSlotsMonitor(this);
+            //     this.orphanedSlotsMonitor.init();
+            //     console.log('[TopologyManager] OrphanedSlotsMonitor initialized');
+            // }
 
             this.isInitialized = true;
             this.hideLoading();


### PR DESCRIPTION
The idle monitor (atdMonitor) determines inactivity by reading the last entry in the NGINX access log. Several automated polling requests were keeping the log perpetually fresh, preventing labs from ever appearing idle and auto-shutting down.

- Add dedicated /td-api/grpc-health NGINX location with access_log off for the gRPC connectivity check (every 30s) instead of hitting the logged gRPC path directly
- Update connectivity-monitor.js to use the new unlogged path
- Add access_log off to /announcements endpoints (polled every 2min by unified-header.js and notification-bell.js)
- Disable OrphanedSlotsMonitor initialization since slot preservation is off by default (ENABLE_SLOT_PRESERVATION=false in nodebuilder), removing unnecessary /nb-api/orphaned-slots polling every 60s